### PR TITLE
Assign colors to tags/services/marks

### DIFF
--- a/cmd/pkappa2/main.go
+++ b/cmd/pkappa2/main.go
@@ -146,12 +146,12 @@ func main() {
 	})
 	rUser.Put("/api/tags", func(w http.ResponseWriter, r *http.Request) {
 		n := r.URL.Query()["name"]
-		if len(n) != 1 || len(n[0]) < 1 {
+		if len(n) != 1 || n[0] == "" {
 			http.Error(w, "`name` parameter missing or empty", http.StatusBadRequest)
 			return
 		}
 		c := r.URL.Query()["color"]
-		if len(c) != 1 || len(c[0]) < 1 {
+		if len(c) != 1 || c[0] == "" {
 			http.Error(w, "`color` parameter missing or empty", http.StatusBadRequest)
 			return
 		}

--- a/cmd/pkappa2/main.go
+++ b/cmd/pkappa2/main.go
@@ -145,13 +145,14 @@ func main() {
 		}
 	})
 	rUser.Put("/api/tags", func(w http.ResponseWriter, r *http.Request) {
-		s := r.URL.Query()["name"]
-		if len(s) != 1 {
-			http.Error(w, "`name` parameter missing", http.StatusBadRequest)
+		n := r.URL.Query()["name"]
+		if len(n) != 1 || len(n[0]) < 1 {
+			http.Error(w, "`name` parameter missing or empty", http.StatusBadRequest)
 			return
 		}
-		if len(s[0]) < 1 {
-			http.Error(w, "`name` parameter empty", http.StatusBadRequest)
+		c := r.URL.Query()["color"]
+		if len(c) != 1 || len(c[0]) < 1 {
+			http.Error(w, "`color` parameter missing or empty", http.StatusBadRequest)
 			return
 		}
 		body, err := ioutil.ReadAll(r.Body)
@@ -159,7 +160,7 @@ func main() {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if err := mgr.AddTag(s[0], string(body)); err != nil {
+		if err := mgr.AddTag(n[0], c[0], string(body)); err != nil {
 			http.Error(w, fmt.Sprintf("add failed: %v", err), http.StatusBadRequest)
 			return
 		}

--- a/cmd/pkappa2/main.go
+++ b/cmd/pkappa2/main.go
@@ -176,6 +176,20 @@ func main() {
 			http.Error(w, "`method` parameter missing or empty", http.StatusBadRequest)
 			return
 		}
+
+		if m[0] == "change_color" {
+			c := r.URL.Query()["color"]
+			if len(c) != 1 || c[0] == "" {
+				http.Error(w, "`color` parameter missing or empty", http.StatusBadRequest)
+				return
+			}
+			if err := mgr.UpdateTagColor(n[0], c[0]); err != nil {
+				http.Error(w, fmt.Sprintf("update failed: %v", err), http.StatusBadRequest)
+				return
+			}
+			return
+		}
+
 		var method func([]uint64) manager.UpdateTagOperation
 		switch m[0] {
 		case "mark_add":

--- a/docs/TODO.txt
+++ b/docs/TODO.txt
@@ -13,7 +13,7 @@ server:
 - improve import speed by ignoring timedout packages instead of having to flush them before processing a new package
 
 both:
-- add tag color
+- allow editing tag colors
 - add a search history
 - support showing alternatives for groups
 - support showing sub query results

--- a/docs/TODO.txt
+++ b/docs/TODO.txt
@@ -13,7 +13,6 @@ server:
 - improve import speed by ignoring timedout packages instead of having to flush them before processing a new package
 
 both:
-- allow editing tag colors
 - add a search history
 - support showing alternatives for groups
 - support showing sub query results

--- a/internal/index/manager/manager.go
+++ b/internal/index/manager/manager.go
@@ -717,6 +717,25 @@ func (mgr *Manager) DelTag(name string) error {
 	return <-c
 }
 
+func (mgr *Manager) UpdateTagColor(name string, color string) error {
+	c := make(chan error)
+	mgr.jobs <- func() {
+		err := func() error {
+			t, ok := mgr.tags[name]
+			if !ok {
+				return fmt.Errorf("unknown tag %q", name)
+			}
+			t.color = color
+			return nil
+		}()
+		c <- err
+		close(c)
+		//nolint:errcheck
+		mgr.saveState()
+	}
+	return <-c
+}
+
 func UpdateTagOperationMarkAddStream(streams []uint64) UpdateTagOperation {
 	s := make([]uint64, 0, len(streams))
 	s = append(s, streams...)

--- a/internal/index/manager/manager.go
+++ b/internal/index/manager/manager.go
@@ -23,10 +23,12 @@ type (
 		query.TagDetails
 		definition string
 		features   query.FeatureSet
+		color      string
 	}
 	TagInfo struct {
 		Name           string
 		Definition     string
+		Color          string
 		MatchingCount  uint
 		UncertainCount uint
 		Referenced     bool
@@ -76,6 +78,7 @@ type (
 		Tags  []struct {
 			Name       string
 			Definition string
+			Color      string
 		}
 		Pcaps []*pcapmetadata.PcapInfo
 	}
@@ -183,6 +186,7 @@ nextStateFile:
 				},
 				definition: t.Definition,
 				features:   q.Conditions.Features(),
+				color:      t.Color,
 			}
 			if strings.HasPrefix(t.Name, "mark/") {
 				ids, ok := q.Conditions.StreamIDs(mgr.nextStreamID)
@@ -268,9 +272,11 @@ func (mgr *Manager) saveState() error {
 		j.Tags = append(j.Tags, struct {
 			Name       string
 			Definition string
+			Color      string
 		}{
 			Name:       n,
 			Definition: t.definition,
+			Color:      t.color,
 		})
 	}
 	fn := tools.MakeFilename(mgr.StateDir, "state.json")
@@ -603,6 +609,7 @@ func (mgr *Manager) ListTags() []TagInfo {
 			res = append(res, TagInfo{
 				Name:           name,
 				Definition:     t.definition,
+				Color:          t.color,
 				MatchingCount:  uint(m.OnesCount()),
 				UncertainCount: uint(t.Uncertain.OnesCount()),
 				Referenced:     referenced,
@@ -617,7 +624,7 @@ func (mgr *Manager) ListTags() []TagInfo {
 	return <-c
 }
 
-func (mgr *Manager) AddTag(name, queryString string) error {
+func (mgr *Manager) AddTag(name, color, queryString string) error {
 	isMark := strings.HasPrefix(name, "mark/")
 	if !(strings.HasPrefix(name, "tag/") || strings.HasPrefix(name, "service/") || isMark) {
 		return errors.New("invalid tag name (need a 'tag/', 'service/' or 'mark/' prefix)")
@@ -642,6 +649,7 @@ func (mgr *Manager) AddTag(name, queryString string) error {
 		},
 		definition: queryString,
 		features:   features,
+		color:      color,
 	}
 	for _, tn := range nt.referencedTags() {
 		if tn == name {

--- a/web/src/apiClient.js
+++ b/web/src/apiClient.js
@@ -27,6 +27,13 @@ const APIClient = {
     delTag(name) {
         return this.perform('delete', `/tags`, null, { name });
     },
+    changeTagColor(name, color) {
+        const params = new URLSearchParams();
+        params.append("name", name);
+        params.append("method", "change_color");
+        params.append("color", color);
+        return this.perform('patch', `/tags`, null, params);
+    },
     getGraph(delta, aspects, tags, query) {
         const params = new URLSearchParams();
         params.append("delta", delta);

--- a/web/src/apiClient.js
+++ b/web/src/apiClient.js
@@ -21,8 +21,8 @@ const APIClient = {
     getTags() {
         return this.perform('get', `/tags`);
     },
-    addTag(name, query) {
-        return this.perform('put', `/tags`, query, { name });
+    addTag(name, query, color) {
+        return this.perform('put', `/tags`, query, { name, color });
     },
     delTag(name) {
         return this.perform('delete', `/tags`, null, { name });
@@ -41,9 +41,9 @@ const APIClient = {
         }
         return this.perform('get', '/graph.json', null, params);
     },
-    markTagNew(name, streams) {
+    markTagNew(name, streams, color) {
         if (streams.length == 0) streams = [-1];
-        return this.addTag(name, `id:${streams.join(',')}`)
+        return this.addTag(name, `id:${streams.join(',')}`, color)
     },
     markTagAdd(name, streams) {
         const params = new URLSearchParams();

--- a/web/src/components/TabResults.vue
+++ b/web/src/components/TabResults.vue
@@ -42,7 +42,7 @@
             hint="Save query as tag(default) or service"
             dense
             @keyup.enter="
-              addTag({ name: 'tag/' + newTagName, query: searchQuery })
+              addTag({ name: 'tag/' + newTagName, query: searchQuery, color: '#ffffff' })
             "
             ><template #append>
               <v-btn
@@ -51,7 +51,7 @@
                 icon
                 :loading="tagAddStatus != null && tagAddStatus.inProgress"
                 @click="
-                  addTag({ name: 'tag/' + newTagName, query: searchQuery })
+                  addTag({ name: 'tag/' + newTagName, query: searchQuery, color: '#ffffff' })
                 "
               >
                 <v-icon>mdi-tag</v-icon>
@@ -62,7 +62,7 @@
                 icon
                 :loading="tagAddStatus != null && tagAddStatus.inProgress"
                 @click="
-                  addTag({ name: 'service/' + newTagName, query: searchQuery })
+                  addTag({ name: 'service/' + newTagName, query: searchQuery, color: '#ffffff' })
                 "
               >
                 <v-icon>mdi-anchor</v-icon>

--- a/web/src/components/TabTags.vue
+++ b/web/src/components/TabTags.vue
@@ -21,7 +21,7 @@
         </tr>
         <template v-for="tag in tags">
           <tr v-if="tag.Name.startsWith(typ + '/')" :key="typ + '/' + tag.Name">
-            <td><v-icon>mdi-circle-small</v-icon>{{ tag.Name.substring(1 + typ.length) }}</td>
+            <td><v-icon>mdi-circle-small</v-icon><v-chip :color="tag.Color">{{ tag.Name.substring(1 + typ.length) }}</v-chip></td>
             <td>{{ tag.Definition }}</td>
             <td>
               Matching {{ tag.MatchingCount }} Streams<span

--- a/web/src/components/new/Base.vue
+++ b/web/src/components/new/Base.vue
@@ -23,6 +23,7 @@
     <TagDeleteDialog />
     <TagCreateDialog />
     <TagDetailsDialog />
+    <TagColorChangeDialog />
     <ErrorBanner />
   </v-app>
 </template>
@@ -33,6 +34,7 @@ import SearchBox from "./SearchBox.vue";
 import TagDeleteDialog from "./TagDeleteDialog.vue";
 import TagCreateDialog from "./TagCreateDialog.vue";
 import TagDetailsDialog from "./TagDetailsDialog.vue";
+import TagColorChangeDialog from "./TagColorChangeDialog.vue";
 import ErrorBanner from "./ErrorBanner.vue";
 
 export default {
@@ -43,6 +45,7 @@ export default {
     TagDeleteDialog,
     TagCreateDialog,
     TagDetailsDialog,
+    TagColorChangeDialog,
     ErrorBanner,
   },
   data() {

--- a/web/src/components/new/Navigation.vue
+++ b/web/src/components/new/Navigation.vue
@@ -99,6 +99,12 @@
                   </v-list-item-icon>
                   <v-list-item-title>Use Query</v-list-item-title>
                 </v-list-item>
+                <v-list-item link @click="showTagColorChangeDialog(tag.Name)">
+                  <v-list-item-icon>
+                    <v-icon>mdi-palette</v-icon>
+                  </v-list-item-icon>
+                  <v-list-item-title>Change Color</v-list-item-title>
+                </v-list-item>
                 <v-list-item
                   link
                   :disabled="tag.Referenced"
@@ -232,6 +238,9 @@ export default {
     },
     setQuery(query) {
       EventBus.$emit("setSearchTerm", { searchTerm: query });
+    },
+    showTagColorChangeDialog(tagId) {
+      EventBus.$emit("showTagColorChangeDialog", { tagId });
     },
   },
   mounted() {

--- a/web/src/components/new/Navigation.vue
+++ b/web/src/components/new/Navigation.vue
@@ -51,9 +51,11 @@
             }"
           >
             <v-list-item-content>
-              <v-list-item-title>{{
-                tag.Name.substr(tagType.key.length + 1)
-              }}</v-list-item-title>
+              <v-list-item-title>
+                <v-chip :color="tag.Color">{{
+                  tag.Name.substr(tagType.key.length + 1)
+                }}</v-chip>
+              </v-list-item-title>
             </v-list-item-content>
             <v-menu offset-y bottom open-on-hover right>
               <template #activator="{ on, attrs }">

--- a/web/src/components/new/Navigation.vue
+++ b/web/src/components/new/Navigation.vue
@@ -38,7 +38,10 @@
         </v-list-item-content>
       </template>
       <template v-for="tag in groupedTags[tagType.key]">
-        <v-hover #default="{ hover }" :key="tag.Name">
+        <v-hover 
+        #default="{ hover }"
+        :key="tag.Name"
+        :style="{ backgroundColor: tag.Color }">
           <v-list-item
             link
             dense
@@ -51,11 +54,9 @@
             }"
           >
             <v-list-item-content>
-              <v-list-item-title>
-                <v-chip :color="tag.Color">{{
+              <v-list-item-title>{{
                   tag.Name.substr(tagType.key.length + 1)
-                }}</v-chip>
-              </v-list-item-title>
+                }}</v-list-item-title>
             </v-list-item-content>
             <v-menu offset-y bottom open-on-hover right>
               <template #activator="{ on, attrs }">

--- a/web/src/components/new/Results.vue
+++ b/web/src/components/new/Results.vue
@@ -202,7 +202,7 @@
               <td class="pl-0">
                 <template v-for="tag in stream.Tags"
                   ><v-hover v-slot="{ hover }" :key="tag"
-                    ><v-chip small
+                    ><v-chip small :color="tags.filter((e) => e.Name == tag)[0].Color"
                       ><template v-if="hover"
                         >{{ tag | tagify("type") | capitalize }}
                         {{ tag | tagify("name") }}</template
@@ -288,7 +288,7 @@ export default {
     window.removeEventListener("keydown", this._keyListener);
   },
   computed: {
-    ...mapState(["streams"]),
+    ...mapState(["streams", "tags"]),
     ...mapGetters(["groupedTags"]),
     selectedCount() {
       return this.selected.filter((i) => i === true).length;

--- a/web/src/components/new/Results.vue
+++ b/web/src/components/new/Results.vue
@@ -202,7 +202,7 @@
               <td class="pl-0">
                 <template v-for="tag in stream.Tags"
                   ><v-hover v-slot="{ hover }" :key="tag"
-                    ><v-chip small :color="tags.filter((e) => e.Name == tag)[0].Color"
+                    ><v-chip small :color="tagColors[tag]"
                       ><template v-if="hover"
                         >{{ tag | tagify("type") | capitalize }}
                         {{ tag | tagify("name") }}</template
@@ -319,6 +319,11 @@ export default {
         res[k] = v == this.selectedStreams.length;
       }
       return res;
+    },
+    tagColors() {
+      const colors = {};
+      this.tags.forEach((t) => colors[t.Name] = t.Color);
+      return colors;
     },
   },
   methods: {

--- a/web/src/components/new/Stream.vue
+++ b/web/src/components/new/Stream.vue
@@ -189,13 +189,17 @@
             >{{ stream.stream.Stream.FirstPacket | formatDate }}</v-col
           >
           <v-col cols="1" class="text-subtitle-2"
-            >{{ tags.service.length == 0 ? "Protocol" : "Service" }}:</v-col
+            >{{ streamTags.service.length == 0 ? "Protocol" : "Service" }}:</v-col
           >
           <v-col cols="1" class="text-subtitle-2">Tags:</v-col>
           <v-col cols="3" class="text-body-2"
-            ><v-chip small v-for="name in tags.tag" :key="`tag/${name}`">{{
-              name
-            }}</v-chip></v-col
+            ><v-chip
+              small
+              v-for="tag in streamTags.tag"
+              :key="`tag/${tag.name}`"
+              :color="tag.color"
+              >{{tag.name}}</v-chip
+            ></v-col
           >
         </v-row>
         <v-row>
@@ -214,24 +218,29 @@
             >{{ stream.stream.Stream.LastPacket | formatDate }}</v-col
           >
           <v-col cols="1" class="text-body-2"
-            ><span v-if="tags.service.length == 0">{{
+            ><span v-if="streamTags.service.length == 0">{{
               stream.stream.Stream.Protocol
             }}</span
             ><span v-else
               ><v-chip
                 small
-                v-for="name in tags.service"
-                :key="`service/${name}`"
-                >{{ name }}</v-chip
+                v-for="service in streamTags.service"
+                :key="`service/${service.name}`"
+                :color="service.color"
+                >{{ service.name }}</v-chip
               >
               ({{ stream.stream.Stream.Protocol }})</span
             ></v-col
           >
           <v-col cols="1" class="text-subtitle-2">Marks:</v-col>
           <v-col cols="3" class="text-body-2"
-            ><v-chip small v-for="name in tags.mark" :key="`mark/${name}`">{{
-              name
-            }}</v-chip></v-col
+            ><v-chip 
+              small
+              v-for="mark in streamTags.mark"
+              :key="`mark/${mark.name}`"
+              :color="mark.color"
+              >{{mark.name}}</v-chip
+            ></v-col
           >
         </v-row>
       </v-container>
@@ -263,9 +272,9 @@ export default {
     };
   },
   computed: {
-    ...mapState(["stream", "streams"]),
+    ...mapState(["stream", "streams", "tags"]),
     ...mapGetters(["groupedTags"]),
-    tags() {
+    streamTags() {
       let res = {
         service: [],
         tag: [],
@@ -274,7 +283,7 @@ export default {
       for (const tag of this.stream.stream.Tags) {
         const type = tag.split("/", 1)[0];
         const name = tag.substr(type.length + 1);
-        res[type].push(name);
+        res[type].push({'name': name, 'color': this.tags.filter((e) => e.Name == tag)[0].Color});
       }
       return res;
     },

--- a/web/src/components/new/TagColorChangeDialog.vue
+++ b/web/src/components/new/TagColorChangeDialog.vue
@@ -3,18 +3,35 @@
     <v-form>
       <v-card>
         <v-card-title>
-          <span class="text-h5">Change Color of {{ tagType | capitalize }} <v-chip :color="tagColor">{{ tagName }}</v-chip></span>
+          <span class="text-h5"
+            >Change Color of {{ tagType | capitalize }}
+            <v-chip :color="tagColor">{{ tagName }}</v-chip></span
+          >
         </v-card-title>
         <v-card-text>
           <v-text-field v-model="tagColor" label="Color" hide-details>
             <template v-slot:append>
-              <v-menu v-model="tagColorPickerOpen" top nudge-bottom="265" nudge-left="32" :close-on-content-click="false">
+              <v-menu
+                v-model="colorPickerOpen"
+                top
+                nudge-bottom="182"
+                nudge-left="32"
+                :close-on-content-click="false"
+              >
                 <template v-slot:activator="{ on }">
                   <div :style="swatchStyle" v-on="on" />
                 </template>
                 <v-card>
                   <v-card-text>
-                    <v-color-picker v-model="tagColor" mode="hexa" hide-mode-switch hide-inputs show-swatches flat />
+                    <v-color-picker
+                      v-model="colorPickerValue"
+                      @update:color="colorPickerValueUpdate"
+                      mode="hexa"
+                      hide-mode-switch
+                      hide-inputs
+                      show-swatches
+                      flat
+                    />
                   </v-card-text>
                 </v-card>
               </v-menu>
@@ -27,7 +44,7 @@
           <v-btn
             text
             @click="updateColor"
-            :disabled="tagColor == '' || loading"
+            :disabled="loading"
             :loading="loading"
             :color="error ? 'error' : 'primary'"
             type="submit"
@@ -53,7 +70,8 @@ export default {
       tagType: "",
       tagName: "",
       tagColor: "",
-      tagColorPickerOpen: false,
+      colorPickerOpen: false,
+      colorPickerValue: "",
     };
   },
   created() {
@@ -63,16 +81,16 @@ export default {
     ...mapState(["tags"]),
     // https://codepen.io/JamieCurnow/pen/KKPjraK
     swatchStyle() {
-      const { tagColor, tagColorPickerOpen } = this
+      const { tagColor, tagColorPickerOpen } = this;
       return {
         backgroundColor: tagColor,
-        cursor: 'pointer',
-        height: '30px',
-        width: '30px',
-        borderRadius: tagColorPickerOpen ? '50%' : '4px',
-        transition: 'border-radius 200ms ease-in-out'
-      }
-    }
+        cursor: "pointer",
+        height: "30px",
+        width: "30px",
+        borderRadius: tagColorPickerOpen ? "50%" : "4px",
+        transition: "border-radius 200ms ease-in-out",
+      };
+    },
   },
   methods: {
     ...mapActions(["changeTagColor"]),
@@ -81,15 +99,18 @@ export default {
       this.tagType = tagId.split("/", 1)[0];
       this.tagName = tagId.substr(this.tagType.length + 1);
       this.tagColor = this.tags.filter((e) => e.Name == tagId)[0].Color;
-      this.tagColorPickerOpen = false;
+      this.colorPickerOpen = false;
       this.visible = true;
       this.loading = false;
       this.error = false;
     },
+    colorPickerValueUpdate(color) {
+      if (this.colorPickerOpen) this.tagColor = color.hex;
+    },
     updateColor() {
       this.loading = true;
       this.error = false;
-      this.changeTagColor({ name: this.tagId,  color: this.tagColor })
+      this.changeTagColor({ name: this.tagId, color: this.tagColor })
         .then(() => {
           this.visible = false;
         })
@@ -98,6 +119,11 @@ export default {
           this.loading = false;
           EventBus.$emit("showError", { message: err });
         });
+    },
+  },
+  watch: {
+    colorPickerOpen(val, old) {
+      if (val && !old) this.colorPickerValue = this.tagColor;
     },
   },
 };

--- a/web/src/components/new/TagCreateDialog.vue
+++ b/web/src/components/new/TagCreateDialog.vue
@@ -8,6 +8,22 @@
         <v-card-text>
           <v-text-field v-model="tagName" label="Name" autofocus></v-text-field>
         </v-card-text>
+        <v-card-text>
+          <v-text-field v-model="tagColor" hide-details>
+            <template v-slot:append>
+              <v-menu v-model="tagColorPickerOpen" top nudge-bottom="165" nudge-left="16" :close-on-content-click="false">
+                <template v-slot:activator="{ on }">
+                  <div :style="swatchStyle" v-on="on" />
+                </template>
+                <v-card>
+                  <v-card-text>
+                    <v-color-picker v-model="tagColor" mode="hexa" hide-mode-switch show-swatches flat />
+                  </v-card-text>
+                </v-card>
+              </v-menu>
+            </template>
+          </v-text-field>
+        </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
           <v-btn text @click="visible = false">Cancel</v-btn>
@@ -41,10 +57,26 @@ export default {
       tagStreams: [],
       tagType: "",
       tagName: "",
+      tagColor: "",
+      tagColorPickerOpen: false,
     };
   },
   created() {
     EventBus.$on("showCreateTagDialog", this.openDialog);
+  },
+  computed: {
+    // https://codepen.io/JamieCurnow/pen/KKPjraK
+    swatchStyle() {
+      const { tagColor, tagColorPickerOpen } = this
+      return {
+        backgroundColor: tagColor,
+        cursor: 'pointer',
+        height: '30px',
+        width: '30px',
+        borderRadius: tagColorPickerOpen ? '50%' : '4px',
+        transition: 'border-radius 200ms ease-in-out'
+      }
+    }
   },
   methods: {
     ...mapActions(["addTag","markTagNew"]),
@@ -53,6 +85,8 @@ export default {
       this.tagQuery = tagQuery;
       this.tagStreams = tagStreams;
       this.tagName = "";
+      this.tagColor = "#81D4FA";
+      this.tagColorPickerOpen = false;
       this.visible = true;
       this.loading = false;
       this.error = false;
@@ -64,10 +98,12 @@ export default {
         ? this.markTagNew({
             name: `${this.tagType}/${this.tagName}`,
             streams: this.tagStreams,
+            color: this.tagColor,
           })
         : this.addTag({
             name: `${this.tagType}/${this.tagName}`,
             query: this.tagQuery,
+            color: this.tagColor,
           })
       )
         .then(() => {

--- a/web/src/components/new/TagCreateDialog.vue
+++ b/web/src/components/new/TagCreateDialog.vue
@@ -83,7 +83,7 @@ export default {
       this.tagQuery = tagQuery;
       this.tagStreams = tagStreams;
       this.tagName = "";
-      this.tagColor = "#81D4FA";
+      this.tagColor = this.randomColor();
       this.tagColorPickerOpen = false;
       this.visible = true;
       this.loading = false;
@@ -112,6 +112,26 @@ export default {
           this.loading = false;
           EventBus.$emit("showError", { message: err });
         });
+    },
+    // https://stackoverflow.com/a/17243070
+    randomColor() {
+      const h = Math.random(), s = 0.6, v = 1.0;
+      var r, g, b, i, f, p, q, t;
+      i = Math.floor(h * 6);
+      f = h * 6 - i;
+      p = v * (1 - s);
+      q = v * (1 - f * s);
+      t = v * (1 - (1 - f) * s);
+      switch (i % 6) {
+          case 0: r = v, g = t, b = p; break;
+          case 1: r = q, g = v, b = p; break;
+          case 2: r = p, g = v, b = t; break;
+          case 3: r = p, g = q, b = v; break;
+          case 4: r = t, g = p, b = v; break;
+          case 5: r = v, g = p, b = q; break;
+      }
+      const toHex = (i) => Math.round(i * 255).toString(16).padStart(2, '0');
+      return '#' + toHex(r) + toHex(g) + toHex(b);
     },
   },
 };

--- a/web/src/components/new/TagCreateDialog.vue
+++ b/web/src/components/new/TagCreateDialog.vue
@@ -9,13 +9,27 @@
           <v-text-field v-model="tagName" label="Name" autofocus></v-text-field>
           <v-text-field v-model="tagColor" label="Color" hide-details>
             <template v-slot:append>
-              <v-menu v-model="tagColorPickerOpen" top nudge-bottom="270" nudge-left="32" :close-on-content-click="false">
+              <v-menu
+                v-model="colorPickerOpen"
+                top
+                nudge-bottom="182"
+                nudge-left="32"
+                :close-on-content-click="false"
+              >
                 <template v-slot:activator="{ on }">
                   <div :style="swatchStyle" v-on="on" />
                 </template>
                 <v-card>
                   <v-card-text>
-                    <v-color-picker v-model="tagColor" mode="hexa" hide-mode-switch hide-inputs show-swatches flat />
+                    <v-color-picker
+                      v-model="colorPickerValue"
+                      @update:color="colorPickerValueUpdate"
+                      mode="hexa"
+                      hide-mode-switch
+                      hide-inputs
+                      show-swatches
+                      flat
+                    />
                   </v-card-text>
                 </v-card>
               </v-menu>
@@ -56,7 +70,8 @@ export default {
       tagType: "",
       tagName: "",
       tagColor: "",
-      tagColorPickerOpen: false,
+      colorPickerOpen: false,
+      colorPickerValue: "",
     };
   },
   created() {
@@ -65,29 +80,32 @@ export default {
   computed: {
     // https://codepen.io/JamieCurnow/pen/KKPjraK
     swatchStyle() {
-      const { tagColor, tagColorPickerOpen } = this
+      const { tagColor, colorPickerOpen } = this;
       return {
         backgroundColor: tagColor,
-        cursor: 'pointer',
-        height: '30px',
-        width: '30px',
-        borderRadius: tagColorPickerOpen ? '50%' : '4px',
-        transition: 'border-radius 200ms ease-in-out'
-      }
-    }
+        cursor: "pointer",
+        height: "30px",
+        width: "30px",
+        borderRadius: colorPickerOpen ? "50%" : "4px",
+        transition: "border-radius 200ms ease-in-out",
+      };
+    },
   },
   methods: {
-    ...mapActions(["addTag","markTagNew"]),
+    ...mapActions(["addTag", "markTagNew"]),
     openDialog({ tagType, tagQuery, tagStreams }) {
       this.tagType = tagType;
       this.tagQuery = tagQuery;
       this.tagStreams = tagStreams;
       this.tagName = "";
       this.tagColor = this.randomColor();
-      this.tagColorPickerOpen = false;
+      this.colorPickerOpen = false;
       this.visible = true;
       this.loading = false;
       this.error = false;
+    },
+    colorPickerValueUpdate(color) {
+      if (this.colorPickerOpen) this.tagColor = color.hex;
     },
     createTag() {
       this.loading = true;
@@ -115,7 +133,9 @@ export default {
     },
     // https://stackoverflow.com/a/17243070
     randomColor() {
-      const h = Math.random(), s = 0.6, v = 1.0;
+      const h = Math.random(),
+        s = 0.6,
+        v = 1.0;
       var r, g, b, i, f, p, q, t;
       i = Math.floor(h * 6);
       f = h * 6 - i;
@@ -123,15 +143,35 @@ export default {
       q = v * (1 - f * s);
       t = v * (1 - (1 - f) * s);
       switch (i % 6) {
-          case 0: r = v, g = t, b = p; break;
-          case 1: r = q, g = v, b = p; break;
-          case 2: r = p, g = v, b = t; break;
-          case 3: r = p, g = q, b = v; break;
-          case 4: r = t, g = p, b = v; break;
-          case 5: r = v, g = p, b = q; break;
+        case 0:
+          (r = v), (g = t), (b = p);
+          break;
+        case 1:
+          (r = q), (g = v), (b = p);
+          break;
+        case 2:
+          (r = p), (g = v), (b = t);
+          break;
+        case 3:
+          (r = p), (g = q), (b = v);
+          break;
+        case 4:
+          (r = t), (g = p), (b = v);
+          break;
+        case 5:
+          (r = v), (g = p), (b = q);
+          break;
       }
-      const toHex = (i) => Math.round(i * 255).toString(16).padStart(2, '0');
-      return '#' + toHex(r) + toHex(g) + toHex(b);
+      const toHex = (i) =>
+        Math.round(i * 255)
+          .toString(16)
+          .padStart(2, "0");
+      return "#" + toHex(r) + toHex(g) + toHex(b);
+    },
+  },
+  watch: {
+    colorPickerOpen(val, old) {
+      if (val && !old) this.colorPickerValue = this.tagColor;
     },
   },
 };

--- a/web/src/components/new/TagCreateDialog.vue
+++ b/web/src/components/new/TagCreateDialog.vue
@@ -7,11 +7,9 @@
         </v-card-title>
         <v-card-text>
           <v-text-field v-model="tagName" label="Name" autofocus></v-text-field>
-        </v-card-text>
-        <v-card-text>
-          <v-text-field v-model="tagColor" hide-details>
+          <v-text-field v-model="tagColor" label="Color" hide-details>
             <template v-slot:append>
-              <v-menu v-model="tagColorPickerOpen" top nudge-bottom="165" nudge-left="16" :close-on-content-click="false">
+              <v-menu v-model="tagColorPickerOpen" top nudge-bottom="270" nudge-left="32" :close-on-content-click="false">
                 <template v-slot:activator="{ on }">
                   <div :style="swatchStyle" v-on="on" />
                 </template>

--- a/web/src/components/new/TagDetailsDialog.vue
+++ b/web/src/components/new/TagDetailsDialog.vue
@@ -7,7 +7,6 @@
         >
       </v-card-title>
       <v-card-text v-if="tag != null">
-        <!--{ "Name": "asd", "Definition": "id:3", "Color": "#FFFFFF", "MatchingCount": 1, "UncertainCount": 0, "Referenced": false }-->
         <v-container>
           <v-row no-gutters>
             <v-col class="text-caption">Matching Streams:</v-col>
@@ -19,15 +18,15 @@
             <v-col>{{ tag.UncertainCount }}</v-col>
             <v-col>{{ tag.Referenced ? "Yes" : "No" }}</v-col>
           </v-row>
-          <v-row>
-            <v-col class="text-caption">Color:</v-col>
-          </v-row>
+          <v-row><v-col></v-col></v-row>
           <v-row no-gutters>
-            <v-col
-              ><v-chip :color="tag.Color">{{ tag.Color }}</v-chip></v-col
+            <v-col cols="4" class="text-caption">Color:</v-col>
+            <v-col cols="8"
+              ><v-chip small :color="tag.Color">{{ tag.Color }}</v-chip></v-col
             >
           </v-row>
-          <v-row>
+          <v-row><v-col></v-col></v-row>
+          <v-row no-gutters>
             <v-col class="text-caption">Definition:</v-col>
           </v-row>
           <v-row no-gutters>

--- a/web/src/components/new/TagDetailsDialog.vue
+++ b/web/src/components/new/TagDetailsDialog.vue
@@ -7,7 +7,7 @@
         >
       </v-card-title>
       <v-card-text v-if="tag != null">
-        <!--{ "Name": "asd", "Definition": "id:3", "MatchingCount": 1, "UncertainCount": 0, "Referenced": false }-->
+        <!--{ "Name": "asd", "Definition": "id:3", "Color": "#FFFFFF", "MatchingCount": 1, "UncertainCount": 0, "Referenced": false }-->
         <v-container>
           <v-row no-gutters>
             <v-col class="text-caption">Matching Streams:</v-col>
@@ -18,6 +18,14 @@
             <v-col>{{ tag.MatchingCount }}</v-col>
             <v-col>{{ tag.UncertainCount }}</v-col>
             <v-col>{{ tag.Referenced ? "Yes" : "No" }}</v-col>
+          </v-row>
+          <v-row>
+            <v-col class="text-caption">Color:</v-col>
+          </v-row>
+          <v-row no-gutters>
+            <v-col
+              ><v-chip :color="tag.Color">{{ tag.Color }}</v-chip></v-col
+            >
           </v-row>
           <v-row>
             <v-col class="text-caption">Definition:</v-col>
@@ -66,7 +74,6 @@ export default {
   },
   methods: {
     openDialog({ tagId }) {
-      console.log("asd", tagId);
       this.tagId = tagId;
       this.tagType = tagId.split("/", 1)[0];
       this.tagName = this.tagId.substr(this.tagType.length + 1);

--- a/web/src/components/new/Tags.vue
+++ b/web/src/components/new/Tags.vue
@@ -18,7 +18,7 @@
         <tr v-for="tag in groupedTags[tagType.key]" :key="tag.Name">
           <td>
             <v-icon>mdi-circle-small</v-icon
-            >{{ tag.Name.substring(1 + tagType.key.length) }}
+            ><v-chip :color="tag.Color">{{ tag.Name.substring(1 + tagType.key.length) }}</v-chip>
           </td>
           <td>{{ tag.Definition }}</td>
           <td>

--- a/web/src/components/new/Tags.vue
+++ b/web/src/components/new/Tags.vue
@@ -65,6 +65,18 @@
                 <v-btn
                   v-bind="attrs"
                   v-on="on"
+                  icon
+                  @click="showTagColorChangeDialog(tag.Name)"
+                  ><v-icon>mdi-palette</v-icon></v-btn
+                >
+              </template>
+              <span>Change Color</span>
+            </v-tooltip>
+            <v-tooltip bottom>
+              <template #activator="{ on, attrs }">
+                <v-btn
+                  v-bind="attrs"
+                  v-on="on"
                   :disabled="tag.Referenced"
                   icon
                   @click="confirmTagDeletion(tag.Name)"
@@ -121,6 +133,9 @@ export default {
     },
     setQuery(query) {
       EventBus.$emit("setSearchTerm", { searchTerm: query });
+    },
+    showTagColorChangeDialog(tagId) {
+      EventBus.$emit("showTagColorChangeDialog", { tagId });
     },
   },
 };

--- a/web/src/components/new/Tags.vue
+++ b/web/src/components/new/Tags.vue
@@ -18,7 +18,7 @@
         <tr v-for="tag in groupedTags[tagType.key]" :key="tag.Name">
           <td>
             <v-icon>mdi-circle-small</v-icon
-            ><v-chip :color="tag.Color">{{ tag.Name.substring(1 + tagType.key.length) }}</v-chip>
+            ><v-chip :color="tag.Color" small>{{ tag.Name.substring(1 + tagType.key.length) }}</v-chip>
           </td>
           <td>{{ tag.Definition }}</td>
           <td>

--- a/web/src/store.js
+++ b/web/src/store.js
@@ -240,9 +240,9 @@ const store = new Vuex.Store({
                 commit('resetPcaps', data);
             })
         },
-        async addTag({ commit, dispatch }, { name, query }) {
+        async addTag({ commit, dispatch }, { name, query, color }) {
             commit('resetTagAddStatus', { inProgress: true })
-            return APIClient.addTag(name, query).then(() => {
+            return APIClient.addTag(name, query, color).then(() => {
                 commit('resetTagAddStatus', { inProgress: false })
                 dispatch('updateTags');
             }).catch((err) => {
@@ -266,9 +266,9 @@ const store = new Vuex.Store({
                 commit('resetGraphData', data);
             })
         },
-        async markTagNew({ dispatch, commit }, { name, streams }) {
+        async markTagNew({ dispatch, commit }, { name, streams , color }) {
             commit('resetMarkTagNewStatus', { inProgress: true, error: null });
-            return APIClient.markTagNew(name, streams).catch((err) => {
+            return APIClient.markTagNew(name, streams, color).catch((err) => {
                 commit('resetMarkTagNewStatus', { inProgress: false, error: err.response.data });
                 throw err.response.data;
             }).then(() => {

--- a/web/src/store.js
+++ b/web/src/store.js
@@ -261,6 +261,13 @@ const store = new Vuex.Store({
                 throw err.response.data;
             })
         },
+        async changeTagColor({ dispatch }, { name, color }) {
+            return APIClient.changeTagColor(name, color).catch((err) => {
+                throw err.response.data;
+            }).then(() => {
+                dispatch('updateTags');
+            });
+        },
         updateGraph({ commit }, { delta, aspects, tags, query }) {
             APIClient.getGraph(delta, aspects, tags, query).then((data) => {
                 commit('resetGraphData', data);


### PR DESCRIPTION
When creating e.g. a tag, you're now presented with a color picker to choose the color for this tag. Wherever the tag is displayed it is surrounded with a chip of that color for fast recognition.

It's not possible to change the color through the UI yet.

The color is serialized into the state.json with the other metadata for the tags.