### PR TITLE
Add search history

### DIFF
--- a/docs/TODO.txt
+++ b/docs/TODO.txt
@@ -14,7 +14,7 @@ server:
 
 both:
 - add tag color
-- add a search history
+- add search history overlay for recent searches
 - support showing alternatives for groups
 - support showing sub query results
 - add download button for generated python script that replays the stream (https://github.com/secgroup/flower/blob/master/services/flow2pwn.py https://github.com/secgroup/flower/blob/master/services/data2req.py)

--- a/web/src/components/new/searchHistory.js
+++ b/web/src/components/new/searchHistory.js
@@ -1,0 +1,45 @@
+const STORAGE_KEY = "pkappa2_search_history";
+
+function now() {
+    return new Date().getTime();
+}
+
+function getSearches() {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) ?? {};
+}
+
+function getMostRecentSearchTerms() {
+    return Object.entries(getSearches())
+        .sort((a,b) => b[1] - a[1])
+        .map(([term,]) => term);
+}
+
+function updateSearches(searches) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(searches));
+}
+
+export function addSearch(term) {
+    const trimmedSearch = term.trim();
+    if (trimmedSearch === '') {
+        return;
+    }
+    const searches = getSearches();
+    searches[trimmedSearch] = now();
+    updateSearches(searches);
+}
+
+export function getTermAt(index) {
+    const searches = getMostRecentSearchTerms();
+
+    return searches[index % searches.length];
+}
+
+export function getLastTerms(num = 10) {
+    return getMostRecentSearchTerms().slice(0, num);
+}
+
+export default {
+    addSearch,
+    getTermAt,
+    getLastTerms,
+};


### PR DESCRIPTION
# Search History
Local history of search queries

## UI
- Arrow keys up & down to scroll through the history

## Detail
- No duplicates in the history
- Sorted by most recently used -> least recently
- Keep partially entered search term in last history slot when pressing arrow up, so you can go back to it
- Ignore empty (or whitespace-only) search terms