### PR TITLE
Escape tag names in search query

### DIFF
--- a/web/src/components/TabTags.vue
+++ b/web/src/components/TabTags.vue
@@ -58,9 +58,7 @@ export default {
   methods: {
     ...mapActions(["delTag"]),
     searchStreamsForTag(tag) {
-      const typ = tag.Name.split("/", 1)[0];
-      const query = typ + ":\"" + tag.Name.substr(typ.length+1) + "\"";
-      this.$emit("searchStreams", query, 0);
+      this.$emit("searchStreams", this.$options.filters.tagForURI(tag.Name), 0);
     },
   },
 };

--- a/web/src/components/new/Navigation.vue
+++ b/web/src/components/new/Navigation.vue
@@ -46,7 +46,7 @@
             :to="{
               name: 'search',
               query: {
-                q: `${tagType.key}:${tag.Name.substr(tagType.key.length + 1)}`,
+                q: $options.filters.tagForURI(tag.Name),
               },
             }"
           >
@@ -74,9 +74,7 @@
                   :to="{
                     name: 'search',
                     query: {
-                      q: `${tagType.key}:${tag.Name.substr(
-                        tagType.key.length + 1
-                      )}`,
+                      q: $options.filters.tagForURI(tag.Name),
                     },
                   }"
                 >

--- a/web/src/components/new/Tags.vue
+++ b/web/src/components/new/Tags.vue
@@ -38,9 +38,7 @@
                   :to="{
                     name: 'search',
                     query: {
-                      q: `${tagType.key}:${tag.Name.substr(
-                        tagType.key.length + 1
-                      )}`,
+                      q: $options.filters.tagForURI(tag.Name),
                     },
                   }"
                   ><v-icon>mdi-magnify</v-icon></v-btn

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -42,5 +42,14 @@ Vue.filter('formatDateLong', function (time) {
   time = vue.$moment(time).local();
   return time.format('YYYY-MM-DD hh:mm:ss.SSS ZZ');
 })
+Vue.filter('tagForURI', function (tagId) {
+  const type = tagId.split("/", 1)[0];
+  let name = tagId.substr(type.length + 1);
+  if (name.includes('"'))
+    name = name.replaceAll('"', '""');
+  if (/[ "]/.test(name))
+    name = `"${name}"`;
+  return `${type}:${name}`;
+})
 
 vue.$mount('#app')


### PR DESCRIPTION
Tag names can contain spaces or double quotes, which break the `tagtype:tagname` query syntax.
Surround the tag name with double quotes if it contains a space or a double quote itself when generating search queries out of a tag. Escape the double quotes too `"` => `""`.

Fixes #4