### PR TITLE
Fix history index going out of bounds

### DIFF
--- a/docs/TODO.txt
+++ b/docs/TODO.txt
@@ -21,3 +21,6 @@ both:
 - support decoders in data for search and display
 - calculate levenshtein distance to all previous streams and save the stream id with least difference and the difference
 - add documentation
+
+web:
+- history reverse search with strg+r

--- a/web/src/components/new/SearchBox.vue
+++ b/web/src/components/new/SearchBox.vue
@@ -4,7 +4,8 @@
     hide-details
     flat
     prepend-inner-icon="mdi-magnify"
-    v-model="searchBox"
+    :value="searchBox"
+    @input="onInput"
     @keyup.enter="search(null)"
     @keydown.up.prevent="historyUp"
     @keydown.down.prevent="historyDown"
@@ -80,15 +81,22 @@ export default {
     document.body.removeEventListener("keydown", this._keyListener);
   },
   methods: {
+    onInput(updatedText) {
+      this.historyIndex = -1;
+      this.searchBox = updatedText;
+    },
     historyUp() {
       if (this.historyIndex === -1) {
         this.pendingSearch = this.searchBox;
       }
+      let term = getTermAt(this.historyIndex + 1);
+      if (term == null) {
+        return;
+      }
       this.historyIndex++;
-      let term = getTermAt(this.historyIndex);
       if (this.pendingSearch === term) {
-        this.historyIndex++;
-        term = getTermAt(this.historyIndex);
+        this.historyUp();
+        return;
       }
       this.searchBox = term;
     },

--- a/web/src/components/new/searchHistory.js
+++ b/web/src/components/new/searchHistory.js
@@ -31,7 +31,7 @@ export function addSearch(term) {
 export function getTermAt(index) {
     const searches = getMostRecentSearchTerms();
 
-    return searches[index % searches.length];
+    return searches[index];
 }
 
 export function getLastTerms(num = 10) {


### PR DESCRIPTION
* If you keep pressing up in the search bar, the search history will get past the oldest element and reach around to the newest.
* Editing an old search suggestion should be considered a new search item