### PR TITLE
Add autocomplete suggestions for tag/service/mark in queries

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,8 @@
     "apexcharts": "^3.29.0",
     "axios": "^0.21.2",
     "core-js": "^3.6.5",
+    "moo": "^0.5.1",
+    "nearley": "^2.20.1",
     "vue": "^2.6.11",
     "vue-apexcharts": "^1.6.2",
     "vue-moment": "^4.1.0",

--- a/web/src/components/new/Results.vue
+++ b/web/src/components/new/Results.vue
@@ -322,7 +322,7 @@ export default {
     },
     tagColors() {
       const colors = {};
-      this.tags.forEach((t) => colors[t.Name] = t.Color);
+      this.tags?.forEach((t) => colors[t.Name] = t.Color);
       return colors;
     },
   },

--- a/web/src/components/new/Results.vue
+++ b/web/src/components/new/Results.vue
@@ -322,7 +322,7 @@ export default {
     },
     tagColors() {
       const colors = {};
-      this.tags?.forEach((t) => colors[t.Name] = t.Color);
+      this.tags?.forEach((t) => (colors[t.Name] = t.Color));
       return colors;
     },
   },

--- a/web/src/components/new/SearchBox.vue
+++ b/web/src/components/new/SearchBox.vue
@@ -178,10 +178,9 @@ export default {
         return;
       }
       replace = this.$options.filters.tagNameForURI(replace);
-      this.searchBox =
-        this.searchBox.substring(0, this.suggestionStart) +
-        replace +
-        this.searchBox.substring(this.suggestionEnd);
+      const prefix = this.searchBox.substring(0, this.suggestionStart);
+      const suffix = this.searchBox.substring(this.suggestionEnd);
+      this.searchBox = prefix + replace + suffix;
       this.suggestionMenuOpen = false;
     },
     startSuggestionSearch() {

--- a/web/src/components/new/SearchBox.vue
+++ b/web/src/components/new/SearchBox.vue
@@ -65,6 +65,8 @@
             v-for="(item, index) in suggestionItems"
             :key="index"
             @click="applySuggestion(index)"
+            active-class="font-white"
+            :style="{ backgroundColor: tagColors[suggestionType][item] }"
           >
             <v-list-item-title>{{ item }}</v-list-item-title>
           </v-list-item>
@@ -77,7 +79,7 @@
 <script>
 import { EventBus } from "./EventBus";
 import {addSearch, getTermAt} from './searchHistory';
-import { mapGetters } from "vuex";
+import { mapGetters, mapState } from "vuex";
 import suggest from '../../parser/suggest'
 
 export default {
@@ -99,7 +101,21 @@ export default {
     };
   },
   computed: {
+    ...mapState(['tags']),
     ...mapGetters(["groupedTags"]),
+    tagColors() {
+      const tags = {};
+      this.tags.forEach(tag => {
+        const type = tag.Name.split("/", 1)[0];
+        const name = tag.Name.substr(type.length + 1);
+        if (!(type in tags)) {
+          tags[type] = {};
+        }
+        tags[type][name] = tag.Color;
+      });
+
+      return tags;
+    }
   },
   watch: {
     "$route.query.q": function (term) {
@@ -169,6 +185,7 @@ export default {
         this.suggestionItems = suggestionResult.suggestions;
         this.suggestionStart = suggestionResult.start;
         this.suggestionEnd = suggestionResult.end;
+        this.suggestionType = suggestionResult.type;
       }, 200);
     },
     abortSuggestionSearch() {
@@ -247,3 +264,9 @@ export default {
   },
 };
 </script>
+<style scoped>
+.font-white {
+  color: black;
+  font-weight: bold;
+}
+</style>

--- a/web/src/components/new/SearchBox.vue
+++ b/web/src/components/new/SearchBox.vue
@@ -78,9 +78,9 @@
 
 <script>
 import { EventBus } from "./EventBus";
-import {addSearch, getTermAt} from './searchHistory';
+import { addSearch, getTermAt } from "./searchHistory";
 import { mapGetters, mapState } from "vuex";
-import suggest from '../../parser/suggest'
+import suggest from "../../parser/suggest";
 
 export default {
   name: "SearchBox",
@@ -88,24 +88,24 @@ export default {
     return {
       searchBox: this.$route.query.q,
       historyIndex: -1,
-      pendingSearch: '',
+      pendingSearch: "",
       typingDelay: null,
       suggestionItems: [],
       suggestionStart: 0,
       suggestionEnd: 0,
-      suggestionType: 'tag',
+      suggestionType: "tag",
       suggestionSelectedIndex: 0,
-      suggestionMenuOpen: false, 
+      suggestionMenuOpen: false,
       suggestionMenuPosX: 0,
       suggestionMenuPosY: 0,
     };
   },
   computed: {
-    ...mapState(['tags']),
+    ...mapState(["tags"]),
     ...mapGetters(["groupedTags"]),
     tagColors() {
       const tags = {};
-      this.tags.forEach(tag => {
+      this.tags.forEach((tag) => {
         const type = tag.Name.split("/", 1)[0];
         const name = tag.Name.substr(type.length + 1);
         if (!(type in tags)) {
@@ -115,7 +115,7 @@ export default {
       });
 
       return tags;
-    }
+    },
   },
   watch: {
     "$route.query.q": function (term) {
@@ -127,7 +127,9 @@ export default {
         this.suggestionSelectedIndex = 0;
         const cursorIndex = this.$refs.searchBox.$refs.input.selectionStart;
         const fontWidth = 7.05; // @TODO: Calculate the absolute cursor position correctly
-        this.suggestionMenuPosX = cursorIndex * fontWidth + this.$refs.searchBox.$el.getBoundingClientRect().left;
+        this.suggestionMenuPosX =
+          cursorIndex * fontWidth +
+          this.$refs.searchBox.$el.getBoundingClientRect().left;
       }
     },
   },
@@ -144,7 +146,8 @@ export default {
       this.$refs.searchBox.focus();
     };
     document.body.addEventListener("keydown", this._keyListener.bind(this));
-    this.suggestionMenuPosY = this.$refs.searchBox.$el.getBoundingClientRect().bottom;
+    this.suggestionMenuPosY =
+      this.$refs.searchBox.$el.getBoundingClientRect().bottom;
   },
   beforeDestroy() {
     document.body.removeEventListener("keydown", this._keyListener);
@@ -175,7 +178,10 @@ export default {
         return;
       }
       replace = this.$options.filters.tagNameForURI(replace);
-      this.searchBox = this.searchBox.substring(0, this.suggestionStart) + replace + this.searchBox.substring(this.suggestionEnd);
+      this.searchBox =
+        this.searchBox.substring(0, this.suggestionStart) +
+        replace +
+        this.searchBox.substring(this.suggestionEnd);
       this.suggestionMenuOpen = false;
     },
     startSuggestionSearch() {
@@ -217,7 +223,10 @@ export default {
       this.selectSuggestionIndex(this.suggestionSelectedIndex - 1);
     },
     selectSuggestionIndex(index) {
-      this.suggestionSelectedIndex = Math.min(Math.max(index, 0), this.suggestionItems.length - 1);
+      this.suggestionSelectedIndex = Math.min(
+        Math.max(index, 0),
+        this.suggestionItems.length - 1
+      );
     },
     historyUp() {
       if (this.historyIndex === -1) {
@@ -239,7 +248,11 @@ export default {
         return;
       }
       this.historyIndex--;
-      this.setSearchBox(this.historyIndex === -1 ? this.pendingSearch : getTermAt(this.historyIndex));
+      this.setSearchBox(
+        this.historyIndex === -1
+          ? this.pendingSearch
+          : getTermAt(this.historyIndex)
+      );
     },
     search(type) {
       let q = {};

--- a/web/src/components/new/Stream.vue
+++ b/web/src/components/new/Stream.vue
@@ -209,7 +209,9 @@
             >{{ stream.stream.Stream.FirstPacket | formatDate }}</v-col
           >
           <v-col cols="1" class="text-subtitle-2"
-            >{{ streamTags.service.length == 0 ? "Protocol" : "Service" }}:</v-col
+            >{{
+              streamTags.service.length == 0 ? "Protocol" : "Service"
+            }}:</v-col
           >
           <v-col cols="1" class="text-subtitle-2">Tags:</v-col>
           <v-col cols="3" class="text-body-2"
@@ -218,7 +220,7 @@
               v-for="tag in streamTags.tag"
               :key="`tag/${tag.name}`"
               :color="tag.color"
-              >{{tag.name}}</v-chip
+              >{{ tag.name }}</v-chip
             ></v-col
           >
         </v-row>
@@ -254,12 +256,12 @@
           >
           <v-col cols="1" class="text-subtitle-2">Marks:</v-col>
           <v-col cols="3" class="text-body-2"
-            ><v-chip 
+            ><v-chip
               small
               v-for="mark in streamTags.mark"
               :key="`mark/${mark.name}`"
               :color="mark.color"
-              >{{mark.name}}</v-chip
+              >{{ mark.name }}</v-chip
             ></v-col
           >
         </v-row>

--- a/web/src/components/new/Stream.vue
+++ b/web/src/components/new/Stream.vue
@@ -309,7 +309,8 @@ export default {
       for (const tag of this.stream.stream.Tags) {
         const type = tag.split("/", 1)[0];
         const name = tag.substr(type.length + 1);
-        res[type].push({'name': name, 'color': this.tags.filter((e) => e.Name == tag)[0].Color});
+        const color = this.tags.filter((e) => e.Name == tag)[0]?.Color;
+        res[type].push({ name, color });
       }
       return res;
     },

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -44,12 +44,19 @@ Vue.filter('formatDateLong', function (time) {
 })
 Vue.filter('tagForURI', function (tagId) {
   const type = tagId.split("/", 1)[0];
-  let name = tagId.substr(type.length + 1);
-  if (name.includes('"'))
-    name = name.replaceAll('"', '""');
-  if (/[ "]/.test(name))
-    name = `"${name}"`;
+  const name = this.tagNameForURI(tagId.substr(type.length + 1));
+
   return `${type}:${name}`;
+})
+Vue.filter('tagNameForURI', function (tagName) {
+  if (tagName.includes('"')) {
+    tagName = tagName.replaceAll('"', '""');
+  }
+  if (/[ "]/.test(tagName)) {
+    tagName = `"${tagName}"`;
+  }
+
+  return tagName;
 })
 
 vue.$mount('#app')

--- a/web/src/parser/query.js
+++ b/web/src/parser/query.js
@@ -10,6 +10,7 @@ const lexer = moo.compile({
     ws: {match: /[ \t\n\r]+/, lineBreaks: true},
     value: [
         {match: /[:=]"(?:[^"]*|"")*"/, value: x => x.slice(2, -1)},
+        {match: /[:=]"(?:[^"]*|"")*/, value: x => x.slice(2)},
         {match: /[:=](?:(?:[^"\\ \t\n\r]|\\.)(?:[^\\ \t\n\r]|\\.)*)?(?:[^)\\ \t\n\r]|\\.)/, value: x => x.slice(1)},
         {match: /[:=]/, value: () => null},
     ],

--- a/web/src/parser/query.js
+++ b/web/src/parser/query.js
@@ -1,67 +1,69 @@
 // Generated automatically by nearley, version 2.20.1
 // http://github.com/Hardmath123/nearley
 (function () {
-function id(x) { return x[0]; }
+    function id(x) { return x[0]; }
 
-/* eslint-disable */
-const moo = require("moo");
+    /* eslint-disable */
+    const moo = require("moo");
 
-const lexer = moo.compile({
-    ws: {match: /[ \t\n\r]+/, lineBreaks: true},
-    value: [
-        {match: /[:=]"(?:[^"]*|"")*"/, value: x => x.slice(2, -1)},
-        {match: /[:=]"(?:[^"]*|"")*/, value: x => x.slice(2)},
-        {match: /[:=](?:(?:[^"\\ \t\n\r]|\\.)(?:[^\\ \t\n\r]|\\.)*)?(?:[^)\\ \t\n\r]|\\.)/, value: x => x.slice(1)},
-        {match: /[:=]/, value: () => null},
-    ],
-    lparen: '(',
-    rparen: ')',
-    subquery: {match: /@[a-z0-9]+:/, value: x => x.slice(1, -1)},
-    negation: /[!-]/,
-    keyword_or_error: {match: /[a-zA-Z]+/, error: true, type: moo.keywords({
-        kw: ['id', 'tag', 'service', 'mark', 'protocol', 'ftime', 'ltime', 'time', 'cdata', 'sdata', 'data', 'cport', 'sport', 'port', 'chost', 'shost', 'host', 'cbytes', 'sbytes', 'bytes', 'sort', 'limit', 'group'],
-        'kw_or': 'or',
-        'kw_and': 'and',
-        'kw_then': 'then',
-    })},
-});
-var grammar = {
-    Lexer: lexer,
-    ParserRules: [
-    {"name": "queryRoot$ebnf$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": id},
-    {"name": "queryRoot$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "queryRoot", "symbols": ["queryOrCondition", "queryRoot$ebnf$1"], "postprocess": id},
-    {"name": "queryOrCondition", "symbols": ["queryOrCondition", (lexer.has("ws") ? {type: "ws"} : ws), (lexer.has("kw_or") ? {type: "kw_or"} : kw_or), (lexer.has("ws") ? {type: "ws"} : ws), "queryAndCondition"], "postprocess": (d) => d.length > 1 ? {'type': 'logic', 'op': 'or', 'expressions': [d[0], d[4]]} : d[0]},
-    {"name": "queryOrCondition", "symbols": ["queryAndCondition"], "postprocess": id},
-    {"name": "queryAndCondition$ebnf$1$subexpression$1", "symbols": [(lexer.has("kw_and") ? {type: "kw_and"} : kw_and), (lexer.has("ws") ? {type: "ws"} : ws)]},
-    {"name": "queryAndCondition$ebnf$1", "symbols": ["queryAndCondition$ebnf$1$subexpression$1"], "postprocess": id},
-    {"name": "queryAndCondition$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "queryAndCondition", "symbols": ["queryAndCondition", (lexer.has("ws") ? {type: "ws"} : ws), "queryAndCondition$ebnf$1", "queryThenCondition"], "postprocess": (d) => d.length > 1 ? {'type': 'logic', 'op': 'and', 'expressions': [d[0], d[3]]} : d[0]},
-    {"name": "queryAndCondition", "symbols": ["queryThenCondition"], "postprocess": id},
-    {"name": "queryThenCondition", "symbols": ["queryThenCondition", (lexer.has("ws") ? {type: "ws"} : ws), (lexer.has("kw_then") ? {type: "kw_then"} : kw_then), (lexer.has("ws") ? {type: "ws"} : ws), "queryCondition"], "postprocess": (d) => d.length > 1 ? {'type': 'logic', 'op': 'sequence', 'expressions': [d[0], d[4]]} : d[0]},
-    {"name": "queryThenCondition", "symbols": ["queryCondition"], "postprocess": id},
-    {"name": "queryCondition", "symbols": [(lexer.has("negation") ? {type: "negation"} : negation), "queryCondition"], "postprocess": function(d) {return {'type': 'not', 'expression': d[1]};}},
-    {"name": "queryCondition$ebnf$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": id},
-    {"name": "queryCondition$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "queryCondition$ebnf$2", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": id},
-    {"name": "queryCondition$ebnf$2", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "queryCondition", "symbols": [(lexer.has("lparen") ? {type: "lparen"} : lparen), "queryCondition$ebnf$1", "queryOrCondition", "queryCondition$ebnf$2", (lexer.has("rparen") ? {type: "rparen"} : rparen)], "postprocess": function(d) {return {'type': 'subquery', 'expression': d[2]};}},
-    {"name": "queryCondition$ebnf$3", "symbols": [(lexer.has("subquery") ? {type: "subquery"} : subquery)], "postprocess": id},
-    {"name": "queryCondition$ebnf$3", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "queryCondition$ebnf$4", "symbols": [(lexer.has("value") ? {type: "value"} : value)], "postprocess": id},
-    {"name": "queryCondition$ebnf$4", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "queryCondition", "symbols": ["queryCondition$ebnf$3", (lexer.has("kw") ? {type: "kw"} : kw), "queryCondition$ebnf$4"], "postprocess": function(d) {return {'type': 'expression', 'subquery_var':d[0], 'keyword':d[1], 'value': d[2]};}},
-    {"name": "queryCondition$ebnf$5", "symbols": [(lexer.has("value") ? {type: "value"} : value)], "postprocess": id},
-    {"name": "queryCondition$ebnf$5", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "queryCondition$ebnf$6", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": id},
-    {"name": "queryCondition$ebnf$6", "symbols": [], "postprocess": function(d) {return null;}},
-    {"name": "queryCondition", "symbols": [(lexer.has("keyword_or_error") ? {type: "keyword_or_error"} : keyword_or_error), "queryCondition$ebnf$5", "queryCondition$ebnf$6"], "postprocess": function(d) {return {'type': 'error', 'expression': d[0]};}}
-]
-  , ParserStart: "queryRoot"
-}
-if (typeof module !== 'undefined'&& typeof module.exports !== 'undefined') {
-   module.exports = grammar;
-} else {
-   window.grammar = grammar;
-}
+    const lexer = moo.compile({
+        ws: { match: /[ \t\n\r]+/, lineBreaks: true },
+        value: [
+            { match: /[:=]"(?:[^"]*|"")*"/, value: x => x.slice(2, -1) },
+            { match: /[:=]"(?:[^"]*|"")*/, value: x => x.slice(2) },
+            { match: /[:=](?:(?:[^"\\ \t\n\r]|\\.)(?:[^\\ \t\n\r]|\\.)*)?(?:[^)\\ \t\n\r]|\\.)/, value: x => x.slice(1) },
+            { match: /[:=]/, value: () => null },
+        ],
+        lparen: '(',
+        rparen: ')',
+        subquery: { match: /@[a-z0-9]+:/, value: x => x.slice(1, -1) },
+        negation: /[!-]/,
+        keyword_or_error: {
+            match: /[a-zA-Z]+/, error: true, type: moo.keywords({
+                kw: ['id', 'tag', 'service', 'mark', 'protocol', 'ftime', 'ltime', 'time', 'cdata', 'sdata', 'data', 'cport', 'sport', 'port', 'chost', 'shost', 'host', 'cbytes', 'sbytes', 'bytes', 'sort', 'limit', 'group'],
+                'kw_or': 'or',
+                'kw_and': 'and',
+                'kw_then': 'then',
+            })
+        },
+    });
+    var grammar = {
+        Lexer: lexer,
+        ParserRules: [
+            { "name": "queryRoot$ebnf$1", "symbols": [(lexer.has("ws") ? { type: "ws" } : ws)], "postprocess": id },
+            { "name": "queryRoot$ebnf$1", "symbols": [], "postprocess": function (d) { return null; } },
+            { "name": "queryRoot", "symbols": ["queryOrCondition", "queryRoot$ebnf$1"], "postprocess": id },
+            { "name": "queryOrCondition", "symbols": ["queryOrCondition", (lexer.has("ws") ? { type: "ws" } : ws), (lexer.has("kw_or") ? { type: "kw_or" } : kw_or), (lexer.has("ws") ? { type: "ws" } : ws), "queryAndCondition"], "postprocess": (d) => d.length > 1 ? { 'type': 'logic', 'op': 'or', 'expressions': [d[0], d[4]] } : d[0] },
+            { "name": "queryOrCondition", "symbols": ["queryAndCondition"], "postprocess": id },
+            { "name": "queryAndCondition$ebnf$1$subexpression$1", "symbols": [(lexer.has("kw_and") ? { type: "kw_and" } : kw_and), (lexer.has("ws") ? { type: "ws" } : ws)] },
+            { "name": "queryAndCondition$ebnf$1", "symbols": ["queryAndCondition$ebnf$1$subexpression$1"], "postprocess": id },
+            { "name": "queryAndCondition$ebnf$1", "symbols": [], "postprocess": function (d) { return null; } },
+            { "name": "queryAndCondition", "symbols": ["queryAndCondition", (lexer.has("ws") ? { type: "ws" } : ws), "queryAndCondition$ebnf$1", "queryThenCondition"], "postprocess": (d) => d.length > 1 ? { 'type': 'logic', 'op': 'and', 'expressions': [d[0], d[3]] } : d[0] },
+            { "name": "queryAndCondition", "symbols": ["queryThenCondition"], "postprocess": id },
+            { "name": "queryThenCondition", "symbols": ["queryThenCondition", (lexer.has("ws") ? { type: "ws" } : ws), (lexer.has("kw_then") ? { type: "kw_then" } : kw_then), (lexer.has("ws") ? { type: "ws" } : ws), "queryCondition"], "postprocess": (d) => d.length > 1 ? { 'type': 'logic', 'op': 'sequence', 'expressions': [d[0], d[4]] } : d[0] },
+            { "name": "queryThenCondition", "symbols": ["queryCondition"], "postprocess": id },
+            { "name": "queryCondition", "symbols": [(lexer.has("negation") ? { type: "negation" } : negation), "queryCondition"], "postprocess": function (d) { return { 'type': 'not', 'expression': d[1] }; } },
+            { "name": "queryCondition$ebnf$1", "symbols": [(lexer.has("ws") ? { type: "ws" } : ws)], "postprocess": id },
+            { "name": "queryCondition$ebnf$1", "symbols": [], "postprocess": function (d) { return null; } },
+            { "name": "queryCondition$ebnf$2", "symbols": [(lexer.has("ws") ? { type: "ws" } : ws)], "postprocess": id },
+            { "name": "queryCondition$ebnf$2", "symbols": [], "postprocess": function (d) { return null; } },
+            { "name": "queryCondition", "symbols": [(lexer.has("lparen") ? { type: "lparen" } : lparen), "queryCondition$ebnf$1", "queryOrCondition", "queryCondition$ebnf$2", (lexer.has("rparen") ? { type: "rparen" } : rparen)], "postprocess": function (d) { return { 'type': 'subquery', 'expression': d[2] }; } },
+            { "name": "queryCondition$ebnf$3", "symbols": [(lexer.has("subquery") ? { type: "subquery" } : subquery)], "postprocess": id },
+            { "name": "queryCondition$ebnf$3", "symbols": [], "postprocess": function (d) { return null; } },
+            { "name": "queryCondition$ebnf$4", "symbols": [(lexer.has("value") ? { type: "value" } : value)], "postprocess": id },
+            { "name": "queryCondition$ebnf$4", "symbols": [], "postprocess": function (d) { return null; } },
+            { "name": "queryCondition", "symbols": ["queryCondition$ebnf$3", (lexer.has("kw") ? { type: "kw" } : kw), "queryCondition$ebnf$4"], "postprocess": function (d) { return { 'type': 'expression', 'subquery_var': d[0], 'keyword': d[1], 'value': d[2] }; } },
+            { "name": "queryCondition$ebnf$5", "symbols": [(lexer.has("value") ? { type: "value" } : value)], "postprocess": id },
+            { "name": "queryCondition$ebnf$5", "symbols": [], "postprocess": function (d) { return null; } },
+            { "name": "queryCondition$ebnf$6", "symbols": [(lexer.has("ws") ? { type: "ws" } : ws)], "postprocess": id },
+            { "name": "queryCondition$ebnf$6", "symbols": [], "postprocess": function (d) { return null; } },
+            { "name": "queryCondition", "symbols": [(lexer.has("keyword_or_error") ? { type: "keyword_or_error" } : keyword_or_error), "queryCondition$ebnf$5", "queryCondition$ebnf$6"], "postprocess": function (d) { return { 'type': 'error', 'expression': d[0] }; } }
+        ]
+        , ParserStart: "queryRoot"
+    }
+    if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+        module.exports = grammar;
+    } else {
+        window.grammar = grammar;
+    }
 })();

--- a/web/src/parser/query.js
+++ b/web/src/parser/query.js
@@ -1,0 +1,66 @@
+// Generated automatically by nearley, version 2.20.1
+// http://github.com/Hardmath123/nearley
+(function () {
+function id(x) { return x[0]; }
+
+/* eslint-disable */
+const moo = require("moo");
+
+const lexer = moo.compile({
+    ws: {match: /[ \t\n\r]+/, lineBreaks: true},
+    value: [
+        {match: /[:=]"(?:[^"]*|"")*"/, value: x => x.slice(2, -1)},
+        {match: /[:=](?:(?:[^"\\ \t\n\r]|\\.)(?:[^\\ \t\n\r]|\\.)*)?(?:[^)\\ \t\n\r]|\\.)/, value: x => x.slice(1)},
+        {match: /[:=]/, value: () => null},
+    ],
+    lparen: '(',
+    rparen: ')',
+    subquery: {match: /@[a-z0-9]+:/, value: x => x.slice(1, -1)},
+    negation: /[!-]/,
+    keyword_or_error: {match: /[a-zA-Z]+/, error: true, type: moo.keywords({
+        kw: ['id', 'tag', 'service', 'mark', 'protocol', 'ftime', 'ltime', 'time', 'cdata', 'sdata', 'data', 'cport', 'sport', 'port', 'chost', 'shost', 'host', 'cbytes', 'sbytes', 'bytes', 'sort', 'limit', 'group'],
+        'kw_or': 'or',
+        'kw_and': 'and',
+        'kw_then': 'then',
+    })},
+});
+var grammar = {
+    Lexer: lexer,
+    ParserRules: [
+    {"name": "queryRoot$ebnf$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": id},
+    {"name": "queryRoot$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "queryRoot", "symbols": ["queryOrCondition", "queryRoot$ebnf$1"], "postprocess": id},
+    {"name": "queryOrCondition", "symbols": ["queryOrCondition", (lexer.has("ws") ? {type: "ws"} : ws), (lexer.has("kw_or") ? {type: "kw_or"} : kw_or), (lexer.has("ws") ? {type: "ws"} : ws), "queryAndCondition"], "postprocess": (d) => d.length > 1 ? {'type': 'logic', 'op': 'or', 'expressions': [d[0], d[4]]} : d[0]},
+    {"name": "queryOrCondition", "symbols": ["queryAndCondition"], "postprocess": id},
+    {"name": "queryAndCondition$ebnf$1$subexpression$1", "symbols": [(lexer.has("kw_and") ? {type: "kw_and"} : kw_and), (lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "queryAndCondition$ebnf$1", "symbols": ["queryAndCondition$ebnf$1$subexpression$1"], "postprocess": id},
+    {"name": "queryAndCondition$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "queryAndCondition", "symbols": ["queryAndCondition", (lexer.has("ws") ? {type: "ws"} : ws), "queryAndCondition$ebnf$1", "queryThenCondition"], "postprocess": (d) => d.length > 1 ? {'type': 'logic', 'op': 'and', 'expressions': [d[0], d[3]]} : d[0]},
+    {"name": "queryAndCondition", "symbols": ["queryThenCondition"], "postprocess": id},
+    {"name": "queryThenCondition", "symbols": ["queryThenCondition", (lexer.has("ws") ? {type: "ws"} : ws), (lexer.has("kw_then") ? {type: "kw_then"} : kw_then), (lexer.has("ws") ? {type: "ws"} : ws), "queryCondition"], "postprocess": (d) => d.length > 1 ? {'type': 'logic', 'op': 'sequence', 'expressions': [d[0], d[4]]} : d[0]},
+    {"name": "queryThenCondition", "symbols": ["queryCondition"], "postprocess": id},
+    {"name": "queryCondition", "symbols": [(lexer.has("negation") ? {type: "negation"} : negation), "queryCondition"], "postprocess": function(d) {return {'type': 'not', 'expression': d[1]};}},
+    {"name": "queryCondition$ebnf$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": id},
+    {"name": "queryCondition$ebnf$1", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "queryCondition$ebnf$2", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": id},
+    {"name": "queryCondition$ebnf$2", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "queryCondition", "symbols": [(lexer.has("lparen") ? {type: "lparen"} : lparen), "queryCondition$ebnf$1", "queryOrCondition", "queryCondition$ebnf$2", (lexer.has("rparen") ? {type: "rparen"} : rparen)], "postprocess": function(d) {return {'type': 'subquery', 'expression': d[2]};}},
+    {"name": "queryCondition$ebnf$3", "symbols": [(lexer.has("subquery") ? {type: "subquery"} : subquery)], "postprocess": id},
+    {"name": "queryCondition$ebnf$3", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "queryCondition$ebnf$4", "symbols": [(lexer.has("value") ? {type: "value"} : value)], "postprocess": id},
+    {"name": "queryCondition$ebnf$4", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "queryCondition", "symbols": ["queryCondition$ebnf$3", (lexer.has("kw") ? {type: "kw"} : kw), "queryCondition$ebnf$4"], "postprocess": function(d) {return {'type': 'expression', 'subquery_var':d[0], 'keyword':d[1], 'value': d[2]};}},
+    {"name": "queryCondition$ebnf$5", "symbols": [(lexer.has("value") ? {type: "value"} : value)], "postprocess": id},
+    {"name": "queryCondition$ebnf$5", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "queryCondition$ebnf$6", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": id},
+    {"name": "queryCondition$ebnf$6", "symbols": [], "postprocess": function(d) {return null;}},
+    {"name": "queryCondition", "symbols": [(lexer.has("keyword_or_error") ? {type: "keyword_or_error"} : keyword_or_error), "queryCondition$ebnf$5", "queryCondition$ebnf$6"], "postprocess": function(d) {return {'type': 'error', 'expression': d[0]};}}
+]
+  , ParserStart: "queryRoot"
+}
+if (typeof module !== 'undefined'&& typeof module.exports !== 'undefined') {
+   module.exports = grammar;
+} else {
+   window.grammar = grammar;
+}
+})();

--- a/web/src/parser/query.ne
+++ b/web/src/parser/query.ne
@@ -7,6 +7,7 @@ const lexer = moo.compile({
     ws: {match: /[ \t\n\r]+/, lineBreaks: true},
     value: [
         {match: /[:=]"(?:[^"]*|"")*"/, value: x => x.slice(2, -1)},
+        {match: /[:=]"(?:[^"]*|"")*/, value: x => x.slice(2)},
         {match: /[:=](?:(?:[^"\\ \t\n\r]|\\.)(?:[^\\ \t\n\r]|\\.)*)?(?:[^)\\ \t\n\r]|\\.)/, value: x => x.slice(1)},
         {match: /[:=]/, value: () => null},
     ],

--- a/web/src/parser/query.ne
+++ b/web/src/parser/query.ne
@@ -1,0 +1,43 @@
+# nearleyc query.ne -o query.js
+@{%
+/* eslint-disable */
+const moo = require("moo");
+
+const lexer = moo.compile({
+    ws: {match: /[ \t\n\r]+/, lineBreaks: true},
+    value: [
+        {match: /[:=]"(?:[^"]*|"")*"/, value: x => x.slice(2, -1)},
+        {match: /[:=](?:(?:[^"\\ \t\n\r]|\\.)(?:[^\\ \t\n\r]|\\.)*)?(?:[^)\\ \t\n\r]|\\.)/, value: x => x.slice(1)},
+        {match: /[:=]/, value: () => null},
+    ],
+    lparen: '(',
+    rparen: ')',
+    subquery: {match: /@[a-z0-9]+:/, value: x => x.slice(1, -1)},
+    negation: /[!-]/,
+    keyword_or_error: {match: /[a-zA-Z]+/, error: true, type: moo.keywords({
+        kw: ['id', 'tag', 'service', 'mark', 'protocol', 'ftime', 'ltime', 'time', 'cdata', 'sdata', 'data', 'cport', 'sport', 'port', 'chost', 'shost', 'host', 'cbytes', 'sbytes', 'bytes', 'sort', 'limit', 'group'],
+        'kw_or': 'or',
+        'kw_and': 'and',
+        'kw_then': 'then',
+    })},
+});
+%}
+
+@lexer lexer
+
+# Rules
+queryRoot -> queryOrCondition %ws:? {% id %}
+queryOrCondition ->
+    queryOrCondition %ws %kw_or %ws queryAndCondition {% (d) => d.length > 1 ? {'type': 'logic', 'op': 'or', 'expressions': [d[0], d[4]]} : d[0] %}
+    | queryAndCondition {% id %}
+queryAndCondition ->
+    queryAndCondition %ws (%kw_and %ws):? queryThenCondition {% (d) => d.length > 1 ? {'type': 'logic', 'op': 'and', 'expressions': [d[0], d[3]]} : d[0] %}
+    | queryThenCondition {% id %}
+queryThenCondition ->
+    queryThenCondition %ws %kw_then %ws queryCondition {% (d) => d.length > 1 ? {'type': 'logic', 'op': 'sequence', 'expressions': [d[0], d[4]]} : d[0] %}
+    | queryCondition {% id %}
+queryCondition ->
+    %negation queryCondition  {% function(d) {return {'type': 'not', 'expression': d[1]};} %}
+    | %lparen %ws:? queryOrCondition %ws:? %rparen {% function(d) {return {'type': 'subquery', 'expression': d[2]};} %}
+    | %subquery:? %kw %value:? {% function(d) {return {'type': 'expression', 'subquery_var':d[0], 'keyword':d[1], 'value': d[2]};} %}
+    | %keyword_or_error %value:? %ws:? {% function(d) {return {'type': 'error', 'expression': d[0]};} %}

--- a/web/src/parser/suggest.js
+++ b/web/src/parser/suggest.js
@@ -8,10 +8,9 @@ export default function suggest(query, cursorOffset, groupedTags) {
     try {
         parser.feed(query);
     } catch (parseError) {
-        console.log("Error at character " + parseError.offset); // "Error at character 9"
+        console.log("Error at character " + parseError.offset);
         return { suggestions: [] };
     }
-    // console.log(JSON.stringify(parser.results), cursorOffset);
 
     // Find element at cursor
     const targetElem = _findElementAtCursor(parser.results, cursorOffset);
@@ -23,7 +22,7 @@ export default function suggest(query, cursorOffset, groupedTags) {
     const text = targetElem['value']['text'];
     if (['service', 'tag', 'mark'].includes(keyword)) {
         const start = targetElem['value']['col'];
-        const end = start + (text?.length ?? 0);
+        const end = start + (text?.length ?? 0) - 1;
         const tagsInGroup = groupedTags[keyword].map((t) => t.Name.split('/')[1]);
         const suggestions = tagsInGroup.filter((t) => null == value || (t.startsWith(value) && t !== value));
         return {

--- a/web/src/parser/suggest.js
+++ b/web/src/parser/suggest.js
@@ -30,6 +30,7 @@ export default function suggest(query, cursorOffset, groupedTags) {
             suggestions,
             start,
             end,
+            type: keyword,
         };
     }
     return {suggestions: []};

--- a/web/src/parser/suggest.js
+++ b/web/src/parser/suggest.js
@@ -9,20 +9,20 @@ export default function suggest(query, cursorOffset, groupedTags) {
         parser.feed(query);
     } catch (parseError) {
         console.log("Error at character " + parseError.offset); // "Error at character 9"
-        return {suggestions: []};
+        return { suggestions: [] };
     }
     // console.log(JSON.stringify(parser.results), cursorOffset);
 
     // Find element at cursor
     const targetElem = _findElementAtCursor(parser.results, cursorOffset);
     if (!targetElem)
-        return {suggestions: []};
-    
+        return { suggestions: [] };
+
     const keyword = targetElem['keyword']['value'];
     const value = targetElem['value']['value'];
     const text = targetElem['value']['text'];
     if (['service', 'tag', 'mark'].includes(keyword)) {
-        const start = targetElem['value']['col']; 
+        const start = targetElem['value']['col'];
         const end = start + (text?.length ?? 0);
         const tagsInGroup = groupedTags[keyword].map((t) => t.Name.split('/')[1]);
         const suggestions = tagsInGroup.filter((t) => null == value || (t.startsWith(value) && t !== value));
@@ -33,7 +33,7 @@ export default function suggest(query, cursorOffset, groupedTags) {
             type: keyword,
         };
     }
-    return {suggestions: []};
+    return { suggestions: [] };
 }
 
 function _findElementAtCursor(results, cursorOffset) {
@@ -43,7 +43,7 @@ function _findElementAtCursor(results, cursorOffset) {
         if (elem['type'] === 'expression') {
             if (!elem['value'])
                 continue;
-            
+
             const valueStartOffset = elem['value']['col'];
             const valueEndOffset = valueStartOffset + (elem['value']['text']?.length ?? 0);
             if (cursorOffset >= valueStartOffset && cursorOffset < valueEndOffset)

--- a/web/src/parser/suggest.js
+++ b/web/src/parser/suggest.js
@@ -1,0 +1,51 @@
+import nearley from 'nearley'
+import grammar from './query'
+
+const queryGrammar = nearley.Grammar.fromCompiled(grammar);
+
+export default function suggest(text, cursorOffset, groupedTags) {
+    const parser = new nearley.Parser(queryGrammar);
+    try {
+        parser.feed(text);
+    } catch (parseError) {
+        console.log("Error at character " + parseError.offset); // "Error at character 9"
+        return [];
+    }
+    // console.log(JSON.stringify(parser.results), cursorOffset);
+
+    // Find element at cursor
+    const targetElem = _findElementAtCursor(parser.results, cursorOffset);
+    if (!targetElem)
+        return [];
+    
+    const keyword = targetElem['keyword']['value'];
+    const value = targetElem['value']['value'];
+    if (['service', 'tag', 'mark'].includes(keyword)) {
+        return groupedTags[keyword].map((t) => t.Name.split('/')[1]).filter((t) => !value || t.startsWith(value));
+    }
+    return [];
+}
+
+function _findElementAtCursor(results, cursorOffset) {
+    const elements = [...results];
+    while (elements.length > 0) {
+        const elem = elements.pop();
+        if (elem['type'] === 'expression') {
+            if (!elem['value'])
+                continue;
+            
+            const valueStartOffset = elem['value']['col'];
+            const valueEndOffset = elem['value']['value'] ? valueStartOffset + elem['value']['value'].length : valueStartOffset;
+            if (cursorOffset >= valueStartOffset && cursorOffset <= valueEndOffset)
+                return elem;
+        }
+        else if (elem['type'] === 'logic') {
+            elements.push(...elem['expressions']);
+        }
+        else if (elem['type'] === 'not' || elem['type'] === 'subquery' || elem['type'] === 'error') {
+            if (elem['expression'])
+                elements.push(elem['expression']);
+        }
+    }
+    return null;
+}

--- a/web/src/parser/suggest.js
+++ b/web/src/parser/suggest.js
@@ -11,7 +11,7 @@ export default function suggest(query, cursorOffset, groupedTags) {
         console.log("Error at character " + parseError.offset); // "Error at character 9"
         return {suggestions: []};
     }
-    console.log(JSON.stringify(parser.results), cursorOffset);
+    // console.log(JSON.stringify(parser.results), cursorOffset);
 
     // Find element at cursor
     const targetElem = _findElementAtCursor(parser.results, cursorOffset);

--- a/web/src/parser/test_parser.js
+++ b/web/src/parser/test_parser.js
@@ -1,0 +1,13 @@
+const nearley = require("nearley");
+const grammar = require("./query.js");
+
+const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+try {
+    // parser.feed(`service: service:asd`);
+    parser.feed(`@wat:service:asd or ( tag:"h\ni" and id:444 )`);
+    // parser.feed(`service:"asd" or -service:abc sort:`);
+} catch (parseError) {
+    console.log("Error at character " + parseError.offset); // "Error at character 9"
+}
+
+console.log(JSON.stringify(parser.results));

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2565,7 +2565,7 @@ commander@2.17.x:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@^2.18.0, commander@^2.20.0:
+commander@^2.18.0, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3159,6 +3159,11 @@ dir-glob@^2.0.0, dir-glob@^2.2.2:
   integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
   dependencies:
     path-type "^3.0.0"
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
 dns-equal@^1.0.0:
   version "1.0.0"
@@ -5513,6 +5518,11 @@ moment@^2.19.2:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
+moo@^0.5.0, moo@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
+  integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -5598,6 +5608,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+nearley@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -6713,6 +6733,19 @@ querystringify@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Parses the basic query grammar in the browser using [nearley](https://nearley.js.org/) and displays a menu near the caret when typing `service:`, `tag:`, or `mark:` in the search box. You can use the arrow keys to select between the available options and apply one using tab, enter, or by clicking on the menu item. Focus remains on the input field, so you can continue typing to refine the suggestion or ignore it completely.

![grafik](https://user-images.githubusercontent.com/1635147/158023332-0615a468-f13f-4c51-8180-3ae07ade2acf.png)
