### PR TITLE
Fix querying for IPv4 addresses in "[cs]host"

### DIFF
--- a/internal/query/valueparser.go
+++ b/internal/query/valueparser.go
@@ -221,7 +221,10 @@ func (p *durationParser) Capture(s []string) error {
 func (p *hostParser) Capture(s []string) error {
 	p.Host = net.ParseIP(s[0])
 	if p.Host == nil {
-		return fmt.Errorf("bad ip address %s", net.IP(p.Host).String())
+		return fmt.Errorf("bad ip address %s", s[0])
+	}
+	if p.Host.To4() != nil {
+		p.Host = p.Host.To4()
 	}
 	return nil
 }


### PR DESCRIPTION
The go net.IP package seems to represent IPv4 addresses as "IP4-mapped IPv6" addresses in net.ParseIP, which always makes them appear as being 16 bytes long. The HostCondition checks if the IP address lengths match as an early exit and thus fails to match any IPv4 4-byte addresses.

Fixes #24