### PR TITLE
Check for correct folder permissions on start

### DIFF
--- a/cmd/pkappa2/main.go
+++ b/cmd/pkappa2/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spq/pkappa2/internal/index"
 	"github.com/spq/pkappa2/internal/index/manager"
 	"github.com/spq/pkappa2/internal/query"
+	"github.com/spq/pkappa2/internal/tools"
 	"github.com/spq/pkappa2/web"
 )
 
@@ -40,6 +41,8 @@ var (
 
 func main() {
 	flag.Parse()
+
+	tools.AssertFolderRWXPermissions("base_dir", *baseDir)
 
 	mgr, err := manager.New(
 		filepath.Join(*baseDir, *pcapDir),
@@ -89,6 +92,7 @@ func main() {
 			http.Error(w, "Invalid filename", http.StatusBadRequest)
 			return
 		}
+		tools.AssertFolderRWXPermissions("pcap_dir", filepath.Join(*baseDir, *pcapDir))
 		fullFilename := filepath.Join(*baseDir, *pcapDir, filename)
 
 		dst, err := os.OpenFile(fullFilename, os.O_CREATE|os.O_WRONLY, 0666)

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/go-chi/chi v1.5.4 // indirect
 	github.com/go-chi/chi/v5 v5.0.3 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
+	golang.org/x/sys v0.2.0 // indirect
 	rsc.io/binaryregexp v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/index/manager/manager.go
+++ b/internal/index/manager/manager.go
@@ -122,6 +122,11 @@ func New(pcapDir, indexDir, snapshotDir, stateDir string) (*Manager, error) {
 		tags:        make(map[string]*tag),
 	}
 
+	tools.AssertFolderRWXPermissions("pcap_dir", pcapDir)
+	tools.AssertFolderRWXPermissions("index_dir", indexDir)
+	tools.AssertFolderRWXPermissions("snapshot_dir", snapshotDir)
+	tools.AssertFolderRWXPermissions("state_dir", stateDir)
+
 	// read all existing indexes and load them
 	indexFileNames, err := tools.ListFiles(indexDir, "idx")
 	if err != nil {

--- a/internal/tools/listdir.go
+++ b/internal/tools/listdir.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"io/ioutil"
+	"log"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -19,4 +21,14 @@ func ListFiles(dir, extension string) ([]string, error) {
 		res = append(res, filepath.Join(dir, f.Name()))
 	}
 	return res, nil
+}
+
+func AssertFolderRWXPermissions(name, dir string) {
+	fi, err := os.Lstat(dir)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if fi.Mode().Perm()&0750 != 0750 {
+		log.Fatalf("%s %s has too strict permissions: %#o. Need rwx.", name, dir, fi.Mode().Perm())
+	}
 }

--- a/internal/tools/listdir.go
+++ b/internal/tools/listdir.go
@@ -1,9 +1,9 @@
 package tools
 
 import (
+	"golang.org/x/sys/unix"
 	"io/ioutil"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -24,11 +24,8 @@ func ListFiles(dir, extension string) ([]string, error) {
 }
 
 func AssertFolderRWXPermissions(name, dir string) {
-	fi, err := os.Lstat(dir)
+	err := unix.Access(dir, unix.R_OK|unix.W_OK|unix.X_OK)
 	if err != nil {
-		log.Fatal(err)
-	}
-	if fi.Mode().Perm()&0750 != 0750 {
-		log.Fatalf("%s %s has too strict permissions: %#o. Need rwx.", name, dir, fi.Mode().Perm())
+		log.Fatalf("%s %s has too strict permissions. Need rwx.", name, dir)
 	}
 }


### PR DESCRIPTION
This prevents accidental folder access permission misconfigurations. When missing the eXecute bit on the base_dir, pkappa2 would start, but always respond "File already exists" when trying to upload a file with no other error message.

There are still ways to fuck up permissions despite this check, but it's better than nothing.

Fixes #19