### PR TITLE
Optimize adding streams to marks

### DIFF
--- a/internal/query/conditions.go
+++ b/internal/query/conditions.go
@@ -984,12 +984,10 @@ func (a ConditionsSet) Or(b ConditionsSet) ConditionsSet {
 }
 
 func (c Conditions) impossible() bool {
-	c = c.clean()
 	return len(c) == 1 && impossibleCondition.equal(c[0])
 }
 
 func (c ConditionsSet) impossible() bool {
-	c = c.clean()
 	return len(c) == 1 && c[0].impossible()
 }
 
@@ -1009,10 +1007,10 @@ func (c ConditionsSet) Clean() ConditionsSet {
 	new := ConditionsSet(nil)
 outer:
 	for _, cc := range c {
+		cc = cc.clean()
 		if cc.impossible() {
 			continue
 		}
-		cc = cc.clean()
 		for i, cc2 := range new {
 			if cc2.equal(cc) {
 				continue outer

--- a/internal/query/conditions.go
+++ b/internal/query/conditions.go
@@ -829,7 +829,6 @@ func (t *queryTerm) QueryConditions(pc *parserContext) (ConditionsSet, error) {
 				cond = append(cond, tcs[1])
 			}
 			conds = append(conds, cond)
-			fmt.Printf("%s\n", conds.String())
 		}
 	case "cdata", "sdata", "data":
 		val := stringParser{}
@@ -885,7 +884,7 @@ func (cs Conditions) invert() ConditionsSet {
 	// !(a & b & c) == !a | !b | !c
 	res := ConditionsSet(nil)
 	for _, c := range cs {
-		res = res.or(c.invert())
+		res = res.Or(c.invert())
 	}
 	return res
 }
@@ -894,7 +893,7 @@ func (c ConditionsSet) invert() ConditionsSet {
 	// !(a | b | c) == (!a & !b & !c)
 	conds := ConditionsSet{}
 	for _, cc := range c {
-		conds = conds.and(cc.invert())
+		conds = conds.And(cc.invert())
 	}
 	return conds
 }
@@ -949,7 +948,7 @@ func (a ConditionsSet) then(b ConditionsSet) ConditionsSet {
 	res := ConditionsSet(nil)
 	for _, c1 := range a {
 		for _, c2 := range b {
-			res = res.or(ConditionsSet{c1.then(c2)})
+			res = res.Or(ConditionsSet{c1.then(c2)})
 		}
 	}
 	return res
@@ -959,7 +958,7 @@ func (a Conditions) and(b Conditions) Conditions {
 	return append(append(Conditions(nil), a...), b...).clean()
 }
 
-func (a ConditionsSet) and(b ConditionsSet) ConditionsSet {
+func (a ConditionsSet) And(b ConditionsSet) ConditionsSet {
 	if len(a) == 0 {
 		return b
 	}
@@ -969,7 +968,7 @@ func (a ConditionsSet) and(b ConditionsSet) ConditionsSet {
 	res := ConditionsSet{}
 	for _, c1 := range a {
 		for _, c2 := range b {
-			res = res.or(ConditionsSet{c1.and(c2)})
+			res = res.Or(ConditionsSet{c1.and(c2)})
 		}
 	}
 	return res
@@ -980,7 +979,7 @@ func (a Conditions) or(b Conditions) ConditionsSet {
 	return ConditionsSet{a, b}
 }
 
-func (a ConditionsSet) or(b ConditionsSet) ConditionsSet {
+func (a ConditionsSet) Or(b ConditionsSet) ConditionsSet {
 	return append(append(ConditionsSet(nil), a...), b...)
 }
 
@@ -1006,7 +1005,7 @@ func (a Conditions) equal(b Conditions) bool {
 	return true
 }
 
-func (c ConditionsSet) clean() ConditionsSet {
+func (c ConditionsSet) Clean() ConditionsSet {
 	new := ConditionsSet(nil)
 outer:
 	for _, cc := range c {
@@ -1732,7 +1731,7 @@ func (c *queryAndCondition) QueryConditions(pc *parserContext) (ConditionsSet, e
 			return nil, err
 		}
 		if cond != nil {
-			conds = conds.and(cond)
+			conds = conds.And(cond)
 		}
 	}
 	return conds, nil
@@ -1746,7 +1745,7 @@ func (c *queryOrCondition) QueryConditions(pc *parserContext) (ConditionsSet, er
 			return nil, err
 		}
 		if cond != nil {
-			conds = conds.or(cond)
+			conds = conds.Or(cond)
 		}
 	}
 	return conds, nil
@@ -2096,5 +2095,5 @@ func (cs ConditionsSet) InlineTagFilters(tags map[string]TagDetails) ConditionsS
 	for _, c := range cs {
 		csNew = append(csNew, c.inlineTagFilter(tags)...)
 	}
-	return csNew.clean()
+	return csNew.Clean()
 }

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -257,7 +257,7 @@ func Parse(q string) (*Query, error) {
 		return nil, err
 	}
 	if cond != nil {
-		cond = cond.clean()
+		cond = cond.Clean()
 		if cond.impossible() {
 			cond = nil
 		} else if len(cond) == 0 {


### PR DESCRIPTION
If the mark had a lot of stream ids in the query (> 2000) adding more
streams to it would take a long time due to reparsing and optimizing the
`id:2,3,4,5,6,...` query multiple times.

This patch modifies the existing tag's Conditions instead of recreating
them from scratch making the addition almost instant.

Removal of a stream still calls `ConditionsSet.Clean()` to normalize
the query, but it's still faster than reparsing the query string.

Generated marks can gather a lot of streams fast.