### PR TITLE
Invalidate cached converter output when streams get updated

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -37,7 +37,7 @@
 - [ ] support showing sub query results
 - [x] add download button for generated python script that replays the stream (https://github.com/secgroup/flower/blob/master/services/flow2pwn.py https://github.com/secgroup/flower/blob/master/services/data2req.py)
 - [ ] optional search result snippets
-- [ ] support filters for search and display, see below for how
+- [x] support filters for search and display, see below for how
 - [ ] calculate levenshtein distance to all previous streams and save the stream id with least difference and the difference
 - [ ] add documentation
 
@@ -62,7 +62,7 @@ the converter feature will be implemented like this:
 - [x] whenever pkappa becomes aware of a stream matching a tag/mark/service that triggers a filter but the output of that filter for this stream is not yet cached, it will queue up a filtering processing
   - [ ] all matches are queued up whenever a tag update job finishes. this could be optimized to only queue new / updated matches
 - [ ] whenever pkappa becomes aware of a stream no longer matching any tag/mark/service that triggers a filter but there exists a cache for the output of the given filter for the stream, that cached info is invalidated
-- [ ] rerun the converter if a stream is updated through new pcaps
+- [x] rerun the converter if a stream is updated through new pcaps
 - [x] the stream request api will get a parameter for selecting the filter to apply, it will support auto, none, filter:<name>
   - [x] the mode auto is the default and will return the original stream data or the single cached filtered stream (if there is exactly one)
 - [x] there will be one cache file per active filter with this format:

--- a/internal/index/converters/cache.go
+++ b/internal/index/converters/cache.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/spq/pkappa2/internal/index"
+	"github.com/spq/pkappa2/internal/tools/bitmask"
 )
 
 type (
@@ -95,4 +96,8 @@ func (cache *CachedConverter) Data(stream *index.Stream) (data []index.Data, cli
 
 func (cache *CachedConverter) DataForSearch(streamID uint64) ([2][]byte, [][2]int, uint64, uint64, error) {
 	return cache.cacheFile.DataForSearch(streamID)
+}
+
+func (cache *CachedConverter) InvalidateChangedStreams(streams *bitmask.LongBitmask) bitmask.LongBitmask {
+	return cache.cacheFile.InvalidateChangedStreams(streams)
 }


### PR DESCRIPTION
Rerun the converter on the stream when there are new packets added to an existing already converted stream. Truncating the file from time to time was implemented already but never triggered, so this isn't fully tested yet.

This only marks them as invalid in memory and won't survive a restart of pkappa2 while the converter hasn't rerun yet. You'll have to delete the cache if you happen to kill pkappa2 in such a state.

Fixes #56