### PR TITLE
Escape regex characters when generating query from selection

### DIFF
--- a/web/src/components/streamSelector.js
+++ b/web/src/components/streamSelector.js
@@ -36,7 +36,7 @@ function escape(text) {
     .split("")
     .map((char) =>
       char.replace(
-        /[^ !#$%&',-/0123456789:;<=>ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz~]/,
+        /[^ !#%&',/0123456789:;<=>ABCDEFGHIJKLMNOPQRSTUVWXYZ_`abcdefghijklmnopqrstuvwxyz~-]/,
         (match) =>
           `\\x{${match
             .charCodeAt(0)


### PR DESCRIPTION
When selecting and searching parts of streams containing `$` or `^` symbols, the resulting search query will probably not find matching streams, especially not the original stream.
This changeset escapes these regex-specific symbols.