### PR TITLE
Add webhook to get notified of processed pcaps

### DIFF
--- a/cmd/pkappa2/main.go
+++ b/cmd/pkappa2/main.go
@@ -809,14 +809,14 @@ func main() {
 		}
 	})
 	rUser.Get("/*", http.FileServer(http.FS(&web.FS{})).ServeHTTP)
-	rUser.Get("/api/pcap_processors", func(w http.ResponseWriter, r *http.Request) {
+	rUser.Get("/api/webhooks", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		if err := json.NewEncoder(w).Encode(mgr.ListPcapProcessorWebhooks()); err != nil {
 			http.Error(w, fmt.Sprintf("Encode failed: %v", err), http.StatusInternalServerError)
 		}
 	})
-	rUser.Delete("/api/pcap_processors", func(w http.ResponseWriter, r *http.Request) {
+	rUser.Delete("/api/webhooks", func(w http.ResponseWriter, r *http.Request) {
 		u := r.URL.Query()["url"]
 		if len(u) != 1 || u[0] == "" {
 			http.Error(w, "`url` parameter missing", http.StatusBadRequest)
@@ -827,7 +827,7 @@ func main() {
 			return
 		}
 	})
-	rUser.Put("/api/pcap_processors", func(w http.ResponseWriter, r *http.Request) {
+	rUser.Put("/api/webhooks", func(w http.ResponseWriter, r *http.Request) {
 		u := r.URL.Query()["url"]
 		if len(u) != 1 || u[0] == "" {
 			http.Error(w, "`url` parameter missing or empty", http.StatusBadRequest)

--- a/cmd/pkappa2/main.go
+++ b/cmd/pkappa2/main.go
@@ -41,13 +41,25 @@ const (
 	pingPeriod = (pongWait * 9) / 10
 )
 
+type webhookUrls []string
+
+func (l *webhookUrls) String() string {
+	return ""
+}
+
+func (l *webhookUrls) Set(value string) error {
+	*l = append(*l, value)
+	return nil
+}
+
 var (
-	baseDir      = flag.String("base_dir", "/tmp", "All paths are relative to this path")
-	pcapDir      = flag.String("pcap_dir", "", "Path where pcaps will be stored")
-	indexDir     = flag.String("index_dir", "", "Path where indexes will be stored")
-	snapshotDir  = flag.String("snapshot_dir", "", "Path where snapshots will be stored")
-	stateDir     = flag.String("state_dir", "", "Path where state files will be stored")
-	converterDir = flag.String("converter_dir", "./converters", "Path where converter executables are searched")
+	baseDir                  = flag.String("base_dir", "/tmp", "All paths are relative to this path")
+	pcapDir                  = flag.String("pcap_dir", "", "Path where pcaps will be stored")
+	indexDir                 = flag.String("index_dir", "", "Path where indexes will be stored")
+	snapshotDir              = flag.String("snapshot_dir", "", "Path where snapshots will be stored")
+	stateDir                 = flag.String("state_dir", "", "Path where state files will be stored")
+	converterDir             = flag.String("converter_dir", "./converters", "Path where converter executables are searched")
+	pcapProcessorWebhookUrls webhookUrls
 
 	userPassword = flag.String("user_password", "", "HTTP auth password for users")
 	pcapPassword = flag.String("pcap_password", "", "HTTP auth password for pcaps")
@@ -58,6 +70,7 @@ var (
 )
 
 func main() {
+	flag.Var(&pcapProcessorWebhookUrls, "pcap_processor_url", "Webhook URL to POST a JSON array of newly processed pcap paths to. Can be passed multiple times.")
 	flag.Parse()
 
 	if *startupCpuprofile != "" {
@@ -78,6 +91,7 @@ func main() {
 		filepath.Join(*baseDir, *snapshotDir),
 		filepath.Join(*baseDir, *stateDir),
 		*converterDir,
+		pcapProcessorWebhookUrls,
 	)
 	if err != nil {
 		log.Fatalf("manager.New failed: %v", err)

--- a/internal/index/manager/manager.go
+++ b/internal/index/manager/manager.go
@@ -1568,7 +1568,16 @@ func (mgr *Manager) ConverterStderr(converterName string, pid int) (*converters.
 }
 
 func (mgr *Manager) triggerPcapProcessedWebhooks(filenames []string) {
-	jsonBody, err := json.Marshal(filenames)
+	var absFilenames []string
+	for _, filename := range filenames {
+		absFilename, err := filepath.Abs(filename)
+		if err != nil {
+			fmt.Printf("error: pcap webhook failed to get absolute path of %q: %v\n", filename, err)
+			continue
+		}
+		absFilenames = append(absFilenames, absFilename)
+	}
+	jsonBody, err := json.Marshal(absFilenames)
 	if err != nil {
 		fmt.Printf("error: webhook body json encode failed: %v\n", err)
 		return
@@ -1602,7 +1611,7 @@ func (mgr *Manager) triggerPcapProcessedWebhook(webhookUrl string, jsonBody []by
 		return nil
 	}()
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
+		fmt.Printf("webhook error: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
POST a http request to the given URLs whenever a pcap was imported successfully.
Allows external tools to process pcaps and add additional info to the streams.

Fixes #44 