### PR TITLE
Show outdated notice on results page on new pcaps

### DIFF
--- a/web/src/components/Results.vue
+++ b/web/src/components/Results.vue
@@ -84,6 +84,14 @@
           </v-list>
         </v-menu>
       </div>
+      <v-alert
+        v-if="streams.outdated"
+        class="toolbar-alert"
+        type="info"
+        outlined
+        dense
+        >Results might be outdated.</v-alert
+      >
       <v-spacer />
       <div
         v-if="
@@ -438,3 +446,8 @@ function regexEscape(text: string) {
     .join("");
 }
 </script>
+<style scoped>
+.toolbar-alert {
+  margin: 0px;
+}
+</style>

--- a/web/src/stores/streams.ts
+++ b/web/src/stores/streams.ts
@@ -9,6 +9,7 @@ interface State {
   running: boolean;
   error: string | null;
   result: SearchResult | null;
+  outdated: boolean;
 }
 
 export const useStreamsStore = defineStore("streams", {
@@ -18,6 +19,7 @@ export const useStreamsStore = defineStore("streams", {
     running: false,
     error: null,
     result: null,
+    outdated: false,
   }),
   actions: {
     async searchStreams(query: string, page: number) {
@@ -27,11 +29,13 @@ export const useStreamsStore = defineStore("streams", {
       this.running = true;
       this.error = null;
       this.result = null;
+      this.outdated = false;
       return APIClient.searchStreams(query, page)
         .then((data) => {
           if ("Error" in data) {
             this.error = data.Error;
             this.result = null;
+            this.outdated = false;
           } else {
             this.error = null;
             this.result = data;
@@ -51,6 +55,7 @@ export const useStreamsStore = defineStore("streams", {
                 ? err.response.data
                 : err.message;
             this.result = null;
+            this.outdated = false;
           } else throw err;
         });
     },

--- a/web/src/stores/websocket.ts
+++ b/web/src/stores/websocket.ts
@@ -174,6 +174,7 @@ export function setupWebsocket() {
             console.error("Invalid pcap processed event:", e);
             return;
           }
+          streamsStore.outdated = true;
           if (store.status != null) {
             store.status.PcapCount = e.PcapStats.PcapCount;
             store.status.ImportJobCount = e.PcapStats.ImportJobCount;


### PR DESCRIPTION
Hint that the query should be rerun to see if the newly arrived data change the results when a new pcap was processed.

![grafik](https://github.com/spq/pkappa2/assets/1635147/5389d5e3-1646-4071-ae0d-7f748d5f4fa4)
