### PR TITLE
Pcap-over-ip

### DIFF
--- a/cmd/pkappa2/main.go
+++ b/cmd/pkappa2/main.go
@@ -179,7 +179,7 @@ func main() {
 			}
 			return
 		}
-		mgr.ImportPcap(filename)
+		mgr.ImportPcaps([]string{filename})
 		http.Error(w, "OK", http.StatusOK)
 	})
 	rUser.Mount("/debug", middleware.Profiler())


### PR DESCRIPTION
Implement PCAP-over-IP support, multiple endpoints are supported.
the implementation had one goroutine per endpoint (1) and one goroutine handling the packets coming from all endpoints together (2).
when pcap handling is complete, a flush signal is sent to (2) which flushes all received packets to 1+ pcaps on disk and triggers the import for them.
Initially and when no packets were in memory when asked to flush, the next received packet is written in its own pcap and processed, this shouldn't happen too often.

fixes #109