### PR TITLE
Fix referencing query data conditions before they are added

### DIFF
--- a/internal/index/search_data.go
+++ b/internal/index/search_data.go
@@ -127,6 +127,7 @@ func (dcc *dataConditionsContainer) add(cc *query.DataCondition, subQuery string
 	if affectsSubquery {
 		return errors.New("SubQueries not yet fully supported")
 	}
+	dcc.conditions = append(dcc.conditions, cc)
 regexElements:
 	for eIdx, e := range cc.Elements {
 		for rIdx := range dcc.regexes {
@@ -140,7 +141,7 @@ regexElements:
 				continue
 			}
 			r.occurence = append(r.occurence, occ{
-				condition: len(dcc.conditions),
+				condition: len(dcc.conditions) - 1,
 				element:   eIdx,
 			})
 			continue regexElements
@@ -164,12 +165,11 @@ regexElements:
 		}
 		dcc.regexes = append(dcc.regexes, regex{
 			occurence: []occ{{
-				condition: len(dcc.conditions),
+				condition: len(dcc.conditions) - 1,
 				element:   eIdx,
 			}},
 		})
 	}
-	dcc.conditions = append(dcc.conditions, cc)
 	return nil
 }
 

--- a/internal/index/search_test.go
+++ b/internal/index/search_test.go
@@ -320,6 +320,15 @@ func TestSearchStreams(t *testing.T) {
 			[]uint64{2},
 		},
 		{
+			"test sequence of data connected using then",
+			[]streamInfo{
+				makeStream("192.168.0.100:123", "192.168.0.1:80", t1.Add(time.Hour*1), []string{"needle1", "needle2", "needle3"}),
+				makeStream("192.168.0.100:234", "192.168.0.1:80", t1.Add(time.Hour*2), []string{"needle2", "needle3", "needle1"}),
+			},
+			"cdata:needle1 then sdata:needle2",
+			[]uint64{0},
+		},
+		{
 			"test protocol:tcp query",
 			[]streamInfo{
 				makeStream("192.168.0.100:123", "192.168.0.1:80", t1.Add(time.Hour*1), []string{"needle0"}),


### PR DESCRIPTION
With "xdata:1 then xdata:2", we only add the condition after searching for reusable regexes, but we added the regex "1" to the structure with the known future position of the cc in dcc.conditions, but it's not yet added. So when searching for regex "2", the data structure contains a reference to the not yet added entry in dcc.conditions.

Fix by @spq

Fixes #196