### PR TITLE
Highlight data filter matches in stream data

### DIFF
--- a/cmd/pkappa2/main.go
+++ b/cmd/pkappa2/main.go
@@ -537,7 +537,7 @@ func main() {
 			Elapsed     int64
 			Offset      uint
 			MoreResults bool
-			DataMatches struct {
+			DataRegexes struct {
 				Client []string
 				Server []string
 			}
@@ -608,7 +608,7 @@ func main() {
 				}
 			}
 		}
-		response.DataMatches = struct {
+		response.DataRegexes = struct {
 			Client []string
 			Server []string
 		}{

--- a/internal/index/manager/manager.go
+++ b/internal/index/manager/manager.go
@@ -753,7 +753,7 @@ func (mgr *Manager) updateTagJob(name string, t tag, tagDetails map[string]query
 		if err != nil {
 			return err
 		}
-		streams, _, err := index.SearchStreams(context.Background(), indexes, &t.Uncertain, q.ReferenceTime, q.Conditions, nil, []query.Sorting{{Key: query.SortingKeyID, Dir: query.SortingDirAscending}}, 0, 0, tagDetails, converters)
+		streams, _, _, err := index.SearchStreams(context.Background(), indexes, &t.Uncertain, q.ReferenceTime, q.Conditions, nil, []query.Sorting{{Key: query.SortingKeyID, Dir: query.SortingDirAscending}}, 0, 0, tagDetails, converters, false)
 		if err != nil {
 			return err
 		}
@@ -2247,7 +2247,7 @@ func (v *View) prefetchTags(ctx context.Context, tags []string, bm bitmask.LongB
 					continue outer
 				}
 			}
-			matches, _, err := index.SearchStreams(ctx, v.indexes, &uncertain, time.Time{}, ti.Conditions, nil, []query.Sorting{{Key: query.SortingKeyID, Dir: query.SortingDirAscending}}, 0, 0, v.tagDetails, v.converters)
+			matches, _, _, err := index.SearchStreams(ctx, v.indexes, &uncertain, time.Time{}, ti.Conditions, nil, []query.Sorting{{Key: query.SortingKeyID, Dir: query.SortingDirAscending}}, 0, 0, v.tagDetails, v.converters, false)
 			if err != nil {
 				return err
 			}
@@ -2303,13 +2303,13 @@ func (v *View) AllStreams(ctx context.Context, f func(StreamContext) error, opti
 	return nil
 }
 
-func (v *View) SearchStreams(ctx context.Context, filter *query.Query, f func(StreamContext) error, options ...StreamsOption) (bool, uint, error) {
+func (v *View) SearchStreams(ctx context.Context, filter *query.Query, f func(StreamContext) error, options ...StreamsOption) (bool, uint, *index.DataRegexes, error) {
 	opts := streamsOptions{}
 	for _, o := range options {
 		o(&opts)
 	}
 	if err := v.fetch(); err != nil {
-		return false, 0, err
+		return false, 0, nil, err
 	}
 	if opts.prefetchAllTags {
 		for tn := range v.tagDetails {
@@ -2321,12 +2321,12 @@ func (v *View) SearchStreams(ctx context.Context, filter *query.Query, f func(St
 		limit = *filter.Limit
 	}
 	offset := opts.page * limit
-	res, hasMore, err := index.SearchStreams(ctx, v.indexes, nil, filter.ReferenceTime, filter.Conditions, filter.Grouping, filter.Sorting, limit, offset, v.tagDetails, v.converters)
+	res, hasMore, dataRegexes, err := index.SearchStreams(ctx, v.indexes, nil, filter.ReferenceTime, filter.Conditions, filter.Grouping, filter.Sorting, limit, offset, v.tagDetails, v.converters, true)
 	if err != nil {
-		return false, 0, err
+		return false, 0, nil, err
 	}
 	if len(res) == 0 {
-		return hasMore, offset, nil
+		return hasMore, offset, dataRegexes, nil
 	}
 	if len(opts.prefetchTags) != 0 {
 		searchedStreams := bitmask.LongBitmask{}
@@ -2334,7 +2334,7 @@ func (v *View) SearchStreams(ctx context.Context, filter *query.Query, f func(St
 			searchedStreams.Set(uint(s.StreamID))
 		}
 		if err := v.prefetchTags(ctx, opts.prefetchTags, searchedStreams); err != nil {
-			return false, 0, err
+			return false, 0, nil, err
 		}
 	}
 	for _, s := range res {
@@ -2342,10 +2342,10 @@ func (v *View) SearchStreams(ctx context.Context, filter *query.Query, f func(St
 			s: s,
 			v: v,
 		}); err != nil {
-			return false, 0, err
+			return false, 0, nil, err
 		}
 	}
-	return hasMore, offset, nil
+	return hasMore, offset, dataRegexes, nil
 }
 
 func (v *View) ReferenceTime() (time.Time, error) {
@@ -2380,10 +2380,6 @@ func (v *View) Stream(streamID uint64) (StreamContext, error) {
 		}, nil
 	}
 	return StreamContext{}, nil
-}
-
-func (v *View) TagDetails() map[string]query.TagDetails {
-	return v.tagDetails
 }
 
 func (c StreamContext) Stream() *index.Stream {

--- a/internal/index/manager/manager.go
+++ b/internal/index/manager/manager.go
@@ -2382,6 +2382,10 @@ func (v *View) Stream(streamID uint64) (StreamContext, error) {
 	return StreamContext{}, nil
 }
 
+func (v *View) TagDetails() map[string]query.TagDetails {
+	return v.tagDetails
+}
+
 func (c StreamContext) Stream() *index.Stream {
 	return c.s
 }

--- a/internal/index/manager/manager_test.go
+++ b/internal/index/manager/manager_test.go
@@ -512,7 +512,7 @@ func TestManagerView(t *testing.T) {
 	if err := mgr.AddTag("tag/bar", "red", ""); err != nil {
 		t.Fatalf("Manager.AddTag failed with error: %v", err)
 	}
-	if m, n, err := view.SearchStreams(context.Background(), q, func(StreamContext) error {
+	if m, n, _, err := view.SearchStreams(context.Background(), q, func(StreamContext) error {
 		return nil
 	}, Limit(1, 1), PrefetchAllTags()); err != nil || n != 1 || !m {
 		t.Fatalf("View.SearchStreams() = %v, %v, %v, want true, 1, nil", m, n, err)

--- a/internal/index/search_test.go
+++ b/internal/index/search_test.go
@@ -493,7 +493,7 @@ func TestSearchStreams(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error parsing query: %v", err)
 			}
-			results, _, err := SearchStreams(context.Background(), []*Reader{r}, nil, q.ReferenceTime, q.Conditions, q.Grouping, q.Sorting, 100, 0, nil, converters)
+			results, _, _, err := SearchStreams(context.Background(), []*Reader{r}, nil, q.ReferenceTime, q.Conditions, q.Grouping, q.Sorting, 100, 0, nil, converters, false)
 			if err != nil {
 				t.Fatalf("Error searching streams: %v", err)
 			}

--- a/web/src/apiClient.guard.ts
+++ b/web/src/apiClient.guard.ts
@@ -57,17 +57,17 @@ export function isSearchResult(obj: unknown): obj is SearchResult {
         typeof typedObj["Elapsed"] === "number" &&
         typeof typedObj["Offset"] === "number" &&
         typeof typedObj["MoreResults"] === "boolean" &&
-        (typedObj["DataMatches"] !== null &&
-            typeof typedObj["DataMatches"] === "object" ||
-            typeof typedObj["DataMatches"] === "function") &&
-        (typedObj["DataMatches"]["Client"] === null ||
-            Array.isArray(typedObj["DataMatches"]["Client"]) &&
-            typedObj["DataMatches"]["Client"].every((e: any) =>
+        (typedObj["DataRegexes"] !== null &&
+            typeof typedObj["DataRegexes"] === "object" ||
+            typeof typedObj["DataRegexes"] === "function") &&
+        (typedObj["DataRegexes"]["Client"] === null ||
+            Array.isArray(typedObj["DataRegexes"]["Client"]) &&
+            typedObj["DataRegexes"]["Client"].every((e: any) =>
                 typeof e === "string"
             )) &&
-        (typedObj["DataMatches"]["Server"] === null ||
-            Array.isArray(typedObj["DataMatches"]["Server"]) &&
-            typedObj["DataMatches"]["Server"].every((e: any) =>
+        (typedObj["DataRegexes"]["Server"] === null ||
+            Array.isArray(typedObj["DataRegexes"]["Server"]) &&
+            typedObj["DataRegexes"]["Server"].every((e: any) =>
                 typeof e === "string"
             ))
     )

--- a/web/src/apiClient.guard.ts
+++ b/web/src/apiClient.guard.ts
@@ -56,7 +56,20 @@ export function isSearchResult(obj: unknown): obj is SearchResult {
         ) &&
         typeof typedObj["Elapsed"] === "number" &&
         typeof typedObj["Offset"] === "number" &&
-        typeof typedObj["MoreResults"] === "boolean"
+        typeof typedObj["MoreResults"] === "boolean" &&
+        (typedObj["DataMatches"] !== null &&
+            typeof typedObj["DataMatches"] === "object" ||
+            typeof typedObj["DataMatches"] === "function") &&
+        (typedObj["DataMatches"]["Client"] === null ||
+            Array.isArray(typedObj["DataMatches"]["Client"]) &&
+            typedObj["DataMatches"]["Client"].every((e: any) =>
+                typeof e === "string"
+            )) &&
+        (typedObj["DataMatches"]["Server"] === null ||
+            Array.isArray(typedObj["DataMatches"]["Server"]) &&
+            typedObj["DataMatches"]["Server"].every((e: any) =>
+                typeof e === "string"
+            ))
     )
 }
 

--- a/web/src/apiClient.ts
+++ b/web/src/apiClient.ts
@@ -42,6 +42,11 @@ export type Error = {
   Error: string;
 };
 
+export type DataMatches = {
+  Client: string[] | null;
+  Server: string[] | null;
+};
+
 /** @see {isSearchResult} ts-auto-guard:type-guard */
 export type SearchResult = {
   Debug: string[];
@@ -49,6 +54,7 @@ export type SearchResult = {
   Elapsed: number;
   Offset: number;
   MoreResults: boolean;
+  DataMatches: DataMatches;
 };
 
 /** @see {isSearchResponse} ts-auto-guard:type-guard */

--- a/web/src/apiClient.ts
+++ b/web/src/apiClient.ts
@@ -42,7 +42,7 @@ export type Error = {
   Error: string;
 };
 
-export type DataMatches = {
+export type DataRegexes = {
   Client: string[] | null;
   Server: string[] | null;
 };
@@ -54,7 +54,7 @@ export type SearchResult = {
   Elapsed: number;
   Offset: number;
   MoreResults: boolean;
-  DataMatches: DataMatches;
+  DataRegexes: DataRegexes;
 };
 
 /** @see {isSearchResponse} ts-auto-guard:type-guard */

--- a/web/src/components/Stream.vue
+++ b/web/src/components/Stream.vue
@@ -339,6 +339,7 @@
         ref="streamData"
         :data="stream.stream.Data"
         :presentation="presentation"
+        :highlight-matches="streams.result?.DataMatches"
       ></StreamData>
     </div>
   </div>

--- a/web/src/components/Stream.vue
+++ b/web/src/components/Stream.vue
@@ -339,7 +339,7 @@
         ref="streamData"
         :data="stream.stream.Data"
         :presentation="presentation"
-        :highlight-matches="streams.result?.DataMatches"
+        :highlight-matches="streams.result?.DataRegexes"
       ></StreamData>
     </div>
   </div>

--- a/web/src/components/StreamData.vue
+++ b/web/src/components/StreamData.vue
@@ -100,11 +100,17 @@ const inlineAscii = (chunk: Data) => {
         highlights.push([match.index, match[0].length]);
       });
     }
+    highlights.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+    if (highlights.length > 0) asciiEscaped[0] = `<span>${asciiEscaped[0]}`;
     for (const [index, length] of highlights) {
-      asciiEscaped[index] = `<span class="mark">${asciiEscaped[index]}`;
+      asciiEscaped[index] =
+        `</span><span class="mark" data-offset="${index}">${asciiEscaped[index]}`;
       asciiEscaped[index + length - 1] =
-        `${asciiEscaped[index + length - 1]}</span>`;
+        `${asciiEscaped[index + length - 1]}</span><span data-offset="${index + length}">`;
     }
+    if (highlights.length > 0)
+      asciiEscaped[chunkData.length - 1] =
+        `${asciiEscaped[chunkData.length - 1]}</span>`;
   }
 
   return asciiEscaped.join("");

--- a/web/src/components/StreamData.vue
+++ b/web/src/components/StreamData.vue
@@ -101,16 +101,21 @@ const inlineAscii = (chunk: Data) => {
       });
     }
     highlights.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
-    if (highlights.length > 0) asciiEscaped[0] = `<span>${asciiEscaped[0]}`;
+    let highlightIndex = 0;
     for (const [index, length] of highlights) {
+      if (highlightIndex > 0) {
+        asciiEscaped[index] = `</span>${asciiEscaped[index]}`;
+      }
       asciiEscaped[index] =
-        `</span><span class="mark" data-offset="${index}">${asciiEscaped[index]}`;
+        `<span class="mark" data-offset="${index}">${asciiEscaped[index]}`;
       asciiEscaped[index + length - 1] =
-        `${asciiEscaped[index + length - 1]}</span><span data-offset="${index + length}">`;
+        `${asciiEscaped[index + length - 1]}</span>`;
+      if (highlightIndex < highlights.length - 1) {
+        asciiEscaped[index + length - 1] =
+          `${asciiEscaped[index + length - 1]}<span data-offset="${index + length}">`;
+      }
+      highlightIndex++;
     }
-    if (highlights.length > 0)
-      asciiEscaped[chunkData.length - 1] =
-        `${asciiEscaped[chunkData.length - 1]}</span>`;
   }
 
   return asciiEscaped.join("");

--- a/web/src/components/StreamData.vue
+++ b/web/src/components/StreamData.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script lang="ts" setup>
-import { Data, DataMatches } from "@/apiClient";
+import { Data, DataRegexes } from "@/apiClient";
 import { PropType, computed } from "vue";
 import { escapeRegex } from "./streamSelector";
 
@@ -48,7 +48,7 @@ const props = defineProps({
     required: true,
   },
   highlightMatches: {
-    type: Object as PropType<DataMatches>,
+    type: Object as PropType<DataRegexes>,
     required: false,
     default: () => ({ Client: null, Server: null }),
   },

--- a/web/src/components/streamSelector.ts
+++ b/web/src/components/streamSelector.ts
@@ -23,15 +23,10 @@ export function destroySelectionListener() {
   listenerBag.clear();
 }
 
-function getFromDataSet(
-  outerBound: Node,
-  container: Node,
-  data: string,
-  fallback = null,
-) {
+function getFromDataSet(outerBound: Node, container: Node, data: string) {
   const node = getDataSetContainer(outerBound, container, data);
-  if (node == null) return fallback;
-  return node.dataset[data] ?? fallback;
+  if (node == null) return null;
+  return node.dataset[data] ?? null;
 }
 
 /**
@@ -43,6 +38,9 @@ function getFromDataSet(
 function getDataSetContainer(outerBound: Node, container: Node, data: string) {
   let currentNode: Node | null = container;
   // Ignore non-HTMLElement nodes and look for ones that have a dataset with our data attribute
+  if (!outerBound.contains(currentNode)) {
+    return null;
+  }
   while (
     !(currentNode instanceof HTMLElement) ||
     currentNode?.dataset?.[data] == null
@@ -81,6 +79,10 @@ function chunkToQueryPart(chunk: Data, data: string) {
 
 function onSelectionChange(this: ThisProxy) {
   const stream = useStreamStore();
+  const chunks = stream.stream?.Data;
+  if (chunks == null) {
+    return;
+  }
   const selection = document.getSelection();
   this.selectionData.value = "";
   this.selectionQuery.value = "";
@@ -107,39 +109,33 @@ function onSelectionChange(this: ThisProxy) {
   }
   const { startContainer, startOffset, endContainer, endOffset } =
     selection.getRangeAt(0);
-  const datasetStartContainer = getDataSetContainer(
+  const startChunkIdxString = getFromDataSet(
     streamDataNode,
     startContainer,
     "chunkIdx",
   );
-  const datasetEndContainer = getDataSetContainer(
+  const endChunkIdxString = getFromDataSet(
     streamDataNode,
     endContainer,
     "chunkIdx",
   );
-  if (
-    datasetStartContainer == null ||
-    datasetEndContainer == null ||
-    !streamDataNode.contains(datasetStartContainer) ||
-    !streamDataNode.contains(datasetEndContainer)
-  ) {
+  if (startChunkIdxString == null || endChunkIdxString == null) {
     return;
   }
-  const chunks = stream.stream?.Data;
-  if (chunks == null) {
-    return;
-  }
-  const startChunkIdx = parseInt(
-    getFromDataSet(streamDataNode, datasetStartContainer, "chunkIdx") ?? "0",
+  const startChunkIdx = parseInt(startChunkIdxString);
+  const endChunkIdx = parseInt(endChunkIdxString);
+  const startOffsetString = getFromDataSet(
+    streamDataNode,
+    startContainer,
+    "offset",
   );
-  const endChunkIdx = parseInt(
-    getFromDataSet(streamDataNode, datasetEndContainer, "chunkIdx") ?? "0",
+  const endOffsetString = getFromDataSet(
+    streamDataNode,
+    endContainer,
+    "offset",
   );
-  if (
-    [startChunkIdx, startOffset, endChunkIdx, endOffset].some((i) => i === null)
-  ) {
-    return;
-  }
+  const startChunkOffset = parseInt(startOffsetString ?? "0") + startOffset;
+  const endChunkOffset = parseInt(endOffsetString ?? "0") + endOffset;
 
   if (startChunkIdx >= chunks.length) {
     return;
@@ -153,8 +149,8 @@ function onSelectionChange(this: ThisProxy) {
     currentChunkIdx++
   ) {
     const chunk = chunks[currentChunkIdx];
-    const start = currentChunkIdx === startChunkIdx ? startOffset : 0;
-    const end = currentChunkIdx === endChunkIdx ? endOffset : undefined;
+    const start = currentChunkIdx === startChunkIdx ? startChunkOffset : 0;
+    const end = currentChunkIdx === endChunkIdx ? endChunkOffset : undefined;
     const data = atob(chunk.Content).substring(start, end);
     queryData += data;
     queryParts.push(chunkToQueryPart(chunk, data));

--- a/web/src/components/streamSelector.ts
+++ b/web/src/components/streamSelector.ts
@@ -55,12 +55,15 @@ function getDataSetContainer(outerBound: Node, container: Node, data: string) {
   return currentNode;
 }
 
+export const escapeRegex =
+  /[^ !#%&',/0123456789:;<=>ABCDEFGHIJKLMNOPQRSTUVWXYZ_`abcdefghijklmnopqrstuvwxyz~-]/;
+
 function escape(text: string) {
   return text
     .split("")
     .map((char) =>
       char.replace(
-        /[^ !#%&',/0123456789:;<=>ABCDEFGHIJKLMNOPQRSTUVWXYZ_`abcdefghijklmnopqrstuvwxyz~-]/,
+        escapeRegex,
         (match) =>
           `\\x{${match
             .charCodeAt(0)


### PR DESCRIPTION
All data filters are highlighted in the stream data view by sending the data filters of the search query per chunk direction and matching them in the browser again.

The regexes are passed as a string and might fail to parse in javascript since they are for the goregexp engine which supports non-standard syntax. Skip highlighting in this case.

This could be improved by just sending the matching ranges instead of the regexes.

![grafik](https://github.com/user-attachments/assets/49cebbf9-7590-4839-a1cc-468747393290)

Fixes #73