### PR TITLE
Add urldecode checkbox

### DIFF
--- a/web/src/components/Stream.vue
+++ b/web/src/components/Stream.vue
@@ -154,13 +154,12 @@
 
       <v-tooltip location="bottom">
         <template #activator="{ props }">
-          <v-checkbox
+          <v-switch
             v-model="urlDecode"
             label="URL Decode"
             density="compact"
             hide-details
             color="primary"
-            style="max-width: fit-content"
             v-bind="props"
           />
         </template>

--- a/web/src/components/Stream.vue
+++ b/web/src/components/Stream.vue
@@ -160,7 +160,7 @@
             density="compact"
             hide-details
             color="primary"
-            style="max-width: fit-content;"
+            style="max-width: fit-content"
             v-bind="props"
           />
         </template>

--- a/web/src/components/Stream.vue
+++ b/web/src/components/Stream.vue
@@ -151,6 +151,22 @@
         </template>
         <span>Select converter view</span>
       </v-tooltip>
+
+      <v-tooltip location="bottom">
+        <template #activator="{ props }">
+          <v-checkbox
+            v-model="urlDecode"
+            label="URL Decode"
+            density="compact"
+            hide-details
+            color="primary"
+            style="max-width: fit-content;"
+            v-bind="props"
+          />
+        </template>
+        <span>URL Decode</span>
+      </v-tooltip>
+
       <v-spacer />
       <div v-if="streamIndex !== null && streams.result !== null">
         <span class="text-caption"
@@ -336,6 +352,7 @@
         :data="stream.stream.Data"
         :presentation="presentation"
         :highlight-matches="streams.result?.DataRegexes"
+        :url-decode="urlDecode"
       ></StreamData>
     </div>
   </div>
@@ -372,6 +389,7 @@ const presentation = ref("ascii");
 const selectionData = ref("");
 const selectionQuery = ref("");
 const streamData = ref<HTMLElement | null>(null);
+const urlDecode = ref(false);
 
 if (localStorage.streamPresentation) {
   presentation.value = localStorage.getItem("streamPresentation") ?? "ascii";

--- a/web/src/components/StreamData.vue
+++ b/web/src/components/StreamData.vue
@@ -88,28 +88,23 @@ const asciiMap = Array.from({ length: 0x100 }, (_, i) => {
   return `&#x${i.toString(16).padStart(2, "0")};`;
 });
 
-const inlineAscii = (chunk: Data) => {
-  let chunkData = atob(chunk.Content);
-  const bytes = new Uint8Array([...chunkData].map((c) => c.charCodeAt(0)));
+const handleURLEncode = (chunkData: string) => {
+  if (!props.urlDecode) {
+    return chunkData;
+  }
   try {
-    chunkData = new TextDecoder("utf-8").decode(bytes);
+    return decodeURIComponent(chunkData);
   } catch (e) {
-    console.error("Failed to decode UTF-8 chunk data:", e);
+    console.error("Failed to URL decode chunk:", e);
+    return chunkData;
   }
+};
 
-  if (props.urlDecode) {
-    try {
-      chunkData = decodeURI(chunkData);
-    } catch (e) {
-      console.error("Failed to URL decode chunk:", e);
-    }
-  }
-
-  const asciiEscaped = chunkData.split("").map((c) => {
-    const charCode = c.charCodeAt(0);
-    return asciiMap[charCode] !== undefined ? asciiMap[charCode] : c;
-  });
-
+const inlineAscii = (chunk: Data) => {
+  const chunkData = handleURLEncode(atob(chunk.Content));
+  const asciiEscaped = chunkData
+    .split("")
+    .map((c) => asciiMap[c.charCodeAt(0)]);
   const highlightMatches =
     chunk.Direction === 0
       ? highlightMatchesClient.value

--- a/web/src/components/StreamData.vue
+++ b/web/src/components/StreamData.vue
@@ -90,18 +90,18 @@ const asciiMap = Array.from({ length: 0x100 }, (_, i) => {
 
 const inlineAscii = (chunk: Data) => {
   let chunkData = atob(chunk.Content);
-  const bytes = new Uint8Array([...chunkData].map(c => c.charCodeAt(0)));
+  const bytes = new Uint8Array([...chunkData].map((c) => c.charCodeAt(0)));
   try {
     chunkData = new TextDecoder("utf-8").decode(bytes);
   } catch (e) {
-    console.error('Failed to decode UTF-8 chunk data:', e);
+    console.error("Failed to decode UTF-8 chunk data:", e);
   }
 
   if (props.urlDecode) {
     try {
       chunkData = decodeURI(chunkData);
     } catch (e) {
-      console.error('Failed to URL decode chunk:', e);
+      console.error("Failed to URL decode chunk:", e);
     }
   }
 
@@ -109,7 +109,7 @@ const inlineAscii = (chunk: Data) => {
     const charCode = c.charCodeAt(0);
     return asciiMap[charCode] !== undefined ? asciiMap[charCode] : c;
   });
-  
+
   const highlightMatches =
     chunk.Direction === 0
       ? highlightMatchesClient.value


### PR DESCRIPTION
Add `URL Decode` checkbox for the ASCII view.
This change allows toggling URL decoding for the ASCII view. Also, update the `inlineAscii` processing function to display UTF-8 symbols properly — for example, when the server sends escaped Unicode characters.