### PR TITLE
Add option for utf-8 decoding of stream data in the frontend

### DIFF
--- a/web/src/components/Stream.vue
+++ b/web/src/components/Stream.vue
@@ -120,6 +120,14 @@
         </v-tooltip>
         <v-tooltip location="bottom">
           <template #activator="{ props }">
+            <v-btn value="utf-8" v-bind="props">
+              <v-icon>mdi-format-font</v-icon>
+            </v-btn>
+          </template>
+          <span>UTF-8</span>
+        </v-tooltip>
+        <v-tooltip location="bottom">
+          <template #activator="{ props }">
             <v-btn value="hexdump" v-bind="props">
               <v-icon>mdi-format-columns</v-icon>
             </v-btn>
@@ -143,9 +151,11 @@
           <v-select
             hide-details
             density="compact"
+            label="Converter"
             :items="selectableConverters"
             :model-value="activeConverter"
             v-bind="props"
+            :style="{ maxWidth: 'fit-content', minWidth: '200px' }"
             @update:model-value="changeConverter"
           />
         </template>
@@ -487,6 +497,8 @@ onMounted(() => {
   fetchStreamForId();
   const proxy = {
     streamData: getCurrentInstance()!.proxy,
+    presentation,
+    urlDecode,
     selectionData,
     selectionQuery,
   };

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,0 +1,52 @@
+import { Data } from "@/apiClient";
+
+export const escapeRegex =
+  /[^ !#%&',/0123456789:;<=>ABCDEFGHIJKLMNOPQRSTUVWXYZ_`abcdefghijklmnopqrstuvwxyz~-]/;
+
+export function escape(text: string) {
+  return text
+    .split("")
+    .map((char) =>
+      char.replace(
+        escapeRegex,
+        (match) =>
+          `\\x{${match
+            .charCodeAt(0)
+            .toString(16)
+            .toUpperCase()
+            .padStart(2, "0")}}`,
+      ),
+    )
+    .join("");
+}
+
+export const tryURLDecodeIfEnabled = (chunkData: string, enabled: boolean) => {
+  if (!enabled) {
+    return chunkData;
+  }
+  try {
+    return decodeURIComponent(chunkData);
+  } catch (e) {
+    console.error("Failed to URL decode chunk:", e);
+    return chunkData;
+  }
+};
+
+export const handleUnicodeDecode = (chunk: Data, urlDecode: boolean) => {
+  const chunkData = tryURLDecodeIfEnabled(atob(chunk.Content), urlDecode);
+  const bytes = new Uint8Array([...chunkData].map((c) => c.charCodeAt(0)));
+  return new TextDecoder("utf-8").decode(bytes);
+};
+
+export const decodeChunkContent = (
+  chunk: Data,
+  presentation: string,
+  urlDecode: boolean,
+) => {
+  if (presentation === "utf-8") {
+    return handleUnicodeDecode(chunk, urlDecode);
+  } else if (presentation === "ascii") {
+    return tryURLDecodeIfEnabled(atob(chunk.Content), urlDecode);
+  }
+  throw new Error(`Unsupported presentation type: ${presentation}.`);
+};


### PR DESCRIPTION
Next to ascii, hexdump, and hex there is a utf-8 view now for the stream data. The chunk data is decoded in the frontend before display. Search for selection works by encoding the selected utf-8 data again and searching for the original bytes.

The unicode codepoints are inserted verbatim.

![grafik](https://github.com/user-attachments/assets/20614732-d611-4370-9027-9eccdb15ef89)

![grafik](https://github.com/user-attachments/assets/cc8a0bbc-e458-415d-a8c7-bff1da4526bb)
