### PR TITLE
Add buttons to copy chunk content to clipboard or open in CyberChef

### DIFF
--- a/web/src/components/ErrorBanner.vue
+++ b/web/src/components/ErrorBanner.vue
@@ -31,6 +31,6 @@ function showMessage(msg: string) {
   message.value = msg;
   color.value = "success";
   visible.value = true;
-  console.error(msg);
+  console.log(msg);
 }
 </script>

--- a/web/src/components/Stream.vue
+++ b/web/src/components/Stream.vue
@@ -416,8 +416,7 @@ import {
 import { formatDate, formatDateLong, tagify } from "@/filters";
 import { getContrastTextColor } from "@/lib/colors";
 import prettyBytes from "pretty-bytes";
-
-const CYBERCHEF_URL = "https://gchq.github.io/CyberChef/";
+import { CYBERCHEF_URL } from "@/lib/constants";
 
 const store = useRootStore();
 const route = useRoute();
@@ -607,7 +606,11 @@ function openInCyberChef() {
     }
   }
   const encoded_data = btoa(data);
-  window.open(`${CYBERCHEF_URL}#input=${encodeURIComponent(encoded_data)}`);
+  window.open(
+    `${CYBERCHEF_URL}#input=${encodeURIComponent(encoded_data)}`,
+    "_blank",
+    "noopener,noreferrer",
+  );
 }
 
 function createMark() {

--- a/web/src/components/StreamData.vue
+++ b/web/src/components/StreamData.vue
@@ -84,7 +84,21 @@
                 </v-tooltip>
               </v-btn-toggle>
             </v-col>
-            <v-col class="v-col-1">
+            <v-col class="v-col-2">
+              <v-tooltip location="bottom">
+                <template #activator="{ props: pprops }">
+                  <v-btn
+                    v-bind="pprops"
+                    size="x-small"
+                    variant="text"
+                    icon="mdi-chef-hat"
+                    @click="openInCyberChef(chunk)"
+                    @click.stop
+                  >
+                  </v-btn>
+                </template>
+                <span>Open in CyberChef</span>
+              </v-tooltip>
               <v-tooltip location="bottom">
                 <template #activator="{ props: pprops }">
                   <v-btn
@@ -209,6 +223,7 @@ import prettyBytes from "pretty-bytes";
 import { getColorScheme } from "@/lib/darkmode";
 import { useStreamStore } from "@/stores/stream";
 import { EventBus } from "./EventBus";
+import { CYBERCHEF_URL } from "@/lib/constants";
 
 const stream = useStreamStore();
 const props = defineProps({
@@ -475,6 +490,14 @@ const copyToClipboard = (chunk: VisualChunk) => {
       EventBus.emit("showError", `Failed to copy to clipboard: ${err}`);
     });
 };
+
+function openInCyberChef(chunk: Data) {
+  window.open(
+    `${CYBERCHEF_URL}#input=${encodeURIComponent(chunk.Content)}`,
+    "_blank",
+    "noopener,noreferrer",
+  );
+}
 </script>
 <style scoped>
 .chunk {

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const CYBERCHEF_URL = "https://gchq.github.io/CyberChef/";


### PR DESCRIPTION
Add two more buttons to the chunk bar header next to the download button to copy the contents or open them in a new CyberChef window.

The copy button copies the content exactly as currently presented. So if the hexdump view is active, the hexdump is copied etc.
The download and CyberChef buttons always use the raw binary data.

![grafik](https://github.com/user-attachments/assets/a8eb1bb1-1c38-4593-a5a1-7030cc64c9c8)

Closes #72