### PR TITLE
Keep results list visible while viewing stream data

### DIFF
--- a/web/src/components.d.ts
+++ b/web/src/components.d.ts
@@ -19,6 +19,7 @@ declare module 'vue' {
     PcapOverIP: typeof import('./components/PcapOverIP.vue')['default']
     Pcaps: typeof import('./components/Pcaps.vue')['default']
     Results: typeof import('./components/Results.vue')['default']
+    ResultsLayout: typeof import('./components/ResultsLayout.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SearchBox: typeof import('./components/SearchBox.vue')['default']

--- a/web/src/components/Results.vue
+++ b/web/src/components/Results.vue
@@ -228,6 +228,7 @@
               role="link"
               @click="isTextSelected() || navigate()"
               @keypress.enter="navigate()"
+              :class="currentStream === stream.Stream.ID ? ['selected'] : []"
             >
               <td style="width: 0" class="pr-0">
                 <v-checkbox-btn
@@ -313,7 +314,14 @@
 import { EventBus } from "./EventBus";
 import { useRootStore } from "@/stores";
 import { useStreamsStore } from "@/stores/streams";
-import { computed, onMounted, onBeforeUnmount, ref, watch } from "vue";
+import {
+  computed,
+  onMounted,
+  onBeforeUnmount,
+  nextTick,
+  ref,
+  watch,
+} from "vue";
 import { RouterLink } from "vue-router";
 import { useRoute, useRouter } from "vue-router";
 import { Result } from "@/apiClient";
@@ -369,6 +377,20 @@ const tagColors = computed(() => {
   tags.value?.forEach((t) => (colors[t.Name] = t.Color));
   return colors;
 });
+const currentStream = computed(() => {
+  return route.name === "stream"
+    ? parseInt(route.params.streamId.toString(), 10)
+    : null;
+});
+
+watch(
+  () => currentStream.value,
+  async () => {
+    await nextTick();
+    const s = document.querySelector(".selected");
+    if (s) s.scrollIntoView({ behavior: "smooth", block: "center" });
+  },
+);
 
 watch(route, () => {
   fetchStreams();
@@ -491,5 +513,8 @@ function regexEscape(text: string) {
 <style scoped>
 .toolbar-alert {
   margin: 0px;
+}
+tr.selected td {
+  background: rgba(var(--v-theme-primary), var(--v-border-opacity));
 }
 </style>

--- a/web/src/components/ResultsLayout.vue
+++ b/web/src/components/ResultsLayout.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="search-layout">
+    <div
+      :class="['top-pane', 'overflow-auto', { 'stream-open': streamOpen }]"
+      v-if="!isExpanded"
+    >
+      <Results />
+    </div>
+    <v-scroll-y-reverse-transition>
+      <div
+        class="bottom-pane elevation-4 border-t overflow-auto"
+        v-if="streamOpen"
+      >
+        <router-view />
+      </div>
+    </v-scroll-y-reverse-transition>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+
+const route = useRoute();
+const streamOpen = computed(() => route.name === "stream");
+const isExpanded = computed(
+  () => streamOpen.value && route.query.expand === "true",
+);
+</script>
+
+<style scoped>
+.search-layout {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 64px);
+}
+.top-pane {
+  flex: 1 1 auto;
+}
+.top-pane.stream-open {
+  flex: 1 1 30%;
+}
+.bottom-pane {
+  flex: 1 1 70%;
+  min-height: 300px;
+}
+</style>

--- a/web/src/components/Stream.vue
+++ b/web/src/components/Stream.vue
@@ -5,6 +5,7 @@
         <template #activator="{ props }">
           <v-btn
             icon
+            exact
             :to="{
               name: 'search',
               query: {
@@ -15,10 +16,19 @@
             }"
             v-bind="props"
           >
-            <v-icon>mdi-arrow-left</v-icon>
+            <v-icon>mdi-close</v-icon>
           </v-btn>
         </template>
         <span>Back to Search Results</span>
+      </v-tooltip>
+      <v-tooltip location="bottom">
+        <template #activator="{ props }">
+          <v-btn icon v-bind="props" @click="toggleExpand()">
+            <v-icon v-if="isExpanded">mdi-fullscreen-exit</v-icon>
+            <v-icon v-else>mdi-fullscreen</v-icon>
+          </v-btn>
+        </template>
+        <span>Expand</span>
       </v-tooltip>
       <v-tooltip location="bottom">
         <template #activator="{ props }">
@@ -200,6 +210,7 @@
                         q: $route.query.q,
                         p: $route.query.p,
                         converter: $route.query.converter,
+                        expand: $route.query.expand,
                       },
                       params: { streamId: prevStreamId },
                     }
@@ -224,6 +235,7 @@
                         q: $route.query.q,
                         p: $route.query.p,
                         converter: $route.query.converter,
+                        expand: $route.query.expand,
                       },
                       params: { streamId: nextStreamId },
                     }
@@ -353,7 +365,7 @@
             ></v-col
           >
         </v-row>
-        <v-row no-gutters>
+        <v-row dense>
           <v-tabs
             v-model="converterTab"
             density="compact"
@@ -532,6 +544,8 @@ watch(presentation, (v) => {
   document.getSelection()?.empty();
 });
 
+const isExpanded = computed(() => route.query.expand === "true");
+
 onMounted(() => {
   fetchStreamForId();
   const proxy = {
@@ -633,5 +647,12 @@ function markStream(tagId: string, value: boolean) {
       );
     });
   }
+}
+
+function toggleExpand() {
+  const query = { ...route.query };
+  if (query.expand === "true") delete query.expand;
+  else query.expand = "true";
+  void router.replace({ query });
 }
 </script>

--- a/web/src/routes.ts
+++ b/web/src/routes.ts
@@ -10,7 +10,7 @@ import Pcaps from "./components/Pcaps.vue";
 import Settings from "./components/Settings.vue";
 import Tags from "./components/Tags.vue";
 import Graph from "./components/Graph.vue";
-import Results from "./components/Results.vue";
+import ResultsLayout from "./components/ResultsLayout.vue";
 import Stream from "./components/Stream.vue";
 
 export default createRouter({
@@ -69,20 +69,22 @@ export default createRouter({
         {
           path: "search",
           name: "search",
-          component: Results,
+          component: ResultsLayout,
           props: (route) => ({
             searchTerm: route.query.q,
             searchPage: route.query.p,
           }),
-        },
-        {
-          path: "stream/:streamId(\\d+)",
-          name: "stream",
-          component: Stream,
-          props: (route) => ({
-            searchTerm: route.query.q,
-            searchPage: route.query.p,
-          }),
+          children: [
+            {
+              path: "/stream/:streamId(\\d+)",
+              name: "stream",
+              component: Stream,
+              props: (route) => ({
+                searchTerm: route.query.q,
+                searchPage: route.query.p,
+              }),
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
Add a `ResultsLayout` component at `/search` (and `stream`) that shows a horizontal split-view with the results list on the top. `Stream` now includes an expand button to make the stream full screen as before. The modifications are minimal, and the behavior of the router is not changed, i.e., it handles the same routes as before.

This PR fixes https://github.com/spq/pkappa2/issues/288, but instead of summarizing the results in a sidebar, it keeps the list visible, as shown in the figure below.

<img width="1879" height="1020" alt="image" src="https://github.com/user-attachments/assets/45b763bc-1a86-4ce4-aa35-262473bf4fd6" />
