### PR TITLE
Disable j/k handlers in Results.vue if a stream is open

### DIFF
--- a/web/src/components/Results.vue
+++ b/web/src/components/Results.vue
@@ -421,6 +421,7 @@ onMounted(() => {
   const keyListener = (e: KeyboardEvent) => {
     if (e.target === null || !(e.target instanceof Element)) return;
     if (["input", "textarea"].includes(e.target.tagName.toLowerCase())) return;
+    if (currentStream.value !== null) return;
 
     if (!Object.keys(handlers).includes(e.key)) return;
     handlers[e.key](e);


### PR DESCRIPTION
This PR fixes https://github.com/spq/pkappa2/issues/305 by disabling the handling of keys in `Results.vue` if a stream is open, resulting in the j/k keys being handled only by the `Stream.vue` component.