### PR TITLE
Aggregate tag update WebSocket events

### DIFF
--- a/internal/index/manager/manager.go
+++ b/internal/index/manager/manager.go
@@ -42,6 +42,10 @@ const (
 
 	pcapOverIPCmdFlush = pcapOverIPCmd(iota)
 	pcapOverIPCmdClose
+
+	// Interval for sending aggregated tag update events to the frontend, to avoid sending
+	// too many events when processing a lot of packets in a short time.
+	tagUpdateEventInterval = time.Second * 1
 )
 
 type (
@@ -58,6 +62,7 @@ type (
 	Event struct {
 		Type                string
 		Tag                 *TagInfo                  `json:",omitempty"`
+		Tags                []*TagInfo                `json:",omitempty"`
 		Converter           *converters.Statistics    `json:",omitempty"`
 		PcapStats           *PcapStatistics           `json:",omitempty"`
 		Config              *Config                   `json:",omitempty"`
@@ -145,7 +150,9 @@ type (
 		convertersWatcher *fsnotify.Watcher
 		pcapsWatcher      *fsnotify.Watcher
 
-		listeners map[chan Event]listener
+		listeners           map[chan Event]listener
+		updatedTagsToSignal map[string]struct{}
+		updatedTagsDone     chan struct{}
 
 		config Config
 	}
@@ -229,12 +236,14 @@ func New(pcapDir, indexDir, snapshotDir, stateDir, converterDir, watchDir string
 		ConverterDir: converterDir,
 		WatchDir:     watchDir,
 
-		usedIndexes:      make(map[*index.Reader]uint),
-		tags:             make(map[string]*tag),
-		converters:       make(map[string]*converters.CachedConverter),
-		streamsToConvert: make(map[string]*bitmask.LongBitmask),
-		jobs:             make(chan func()),
-		listeners:        make(map[chan Event]listener),
+		usedIndexes:         make(map[*index.Reader]uint),
+		tags:                make(map[string]*tag),
+		converters:          make(map[string]*converters.CachedConverter),
+		streamsToConvert:    make(map[string]*bitmask.LongBitmask),
+		jobs:                make(chan func()),
+		listeners:           make(map[chan Event]listener),
+		updatedTagsToSignal: make(map[string]struct{}),
+		updatedTagsDone:     make(chan struct{}),
 
 		config: Config{AutoInsertLimitToQuery: false},
 	}
@@ -442,6 +451,7 @@ nextStateFile:
 	}()
 	mgr.jobs <- func() {
 		go mgr.pcapOverIPPacketHandler()
+		go mgr.tagUpdateEventWorker()
 		mgr.startTaggingJobIfNeeded()
 		mgr.startConverterJobIfNeeded()
 		mgr.startMergeJobIfNeeded()
@@ -481,6 +491,7 @@ func (mgr *Manager) Close() {
 			log.Printf("Failed to close pcaps watcher: %v", err)
 		}
 	}
+	close(mgr.updatedTagsDone)
 	c := make(chan struct{})
 	mgr.jobs <- func() {
 		for _, converter := range mgr.converters {
@@ -1029,10 +1040,7 @@ func (mgr *Manager) AddTag(name, color, queryString string) error {
 				t := mgr.tags[tn]
 				t.referencedBy[name] = struct{}{}
 				if len(t.referencedBy) == 1 {
-					mgr.event(Event{
-						Type: "tagUpdated",
-						Tag:  makeTagInfo(tn, t),
-					})
+					mgr.updatedTagsToSignal[tn] = struct{}{}
 				}
 			}
 			return mgr.saveState()
@@ -1076,10 +1084,7 @@ func (mgr *Manager) DelTag(name string) error {
 				if len(t.referencedBy) != 0 {
 					continue
 				}
-				mgr.event(Event{
-					Type: "tagUpdated",
-					Tag:  makeTagInfo(tn, t),
-				})
+				mgr.updatedTagsToSignal[tn] = struct{}{}
 			}
 			return mgr.saveState()
 		}()
@@ -1216,20 +1221,14 @@ func (mgr *Manager) UpdateTag(name string, operation UpdateTagOperation) error {
 					rt := mgr.tags[rtn]
 					delete(rt.referencedBy, name)
 					if len(rt.referencedBy) == 0 {
-						mgr.event(Event{
-							Type: "tagUpdated",
-							Tag:  makeTagInfo(rtn, rt),
-						})
+						mgr.updatedTagsToSignal[rtn] = struct{}{}
 					}
 				}
 				for rtn := range onlyAfter {
 					rt := mgr.tags[rtn]
 					rt.referencedBy[name] = struct{}{}
 					if len(rt.referencedBy) == 1 {
-						mgr.event(Event{
-							Type: "tagUpdated",
-							Tag:  makeTagInfo(rtn, rt),
-						})
+						mgr.updatedTagsToSignal[rtn] = struct{}{}
 					}
 				}
 				tag = newTag
@@ -1364,15 +1363,13 @@ func (mgr *Manager) UpdateTag(name string, operation UpdateTagOperation) error {
 						Converters: []string{},
 					},
 				})
+				delete(mgr.updatedTagsToSignal, name)
 				mgr.event(Event{
 					Type: "tagAdded",
 					Tag:  makeTagInfo(info.name, tag),
 				})
 			} else {
-				mgr.event(Event{
-					Type: "tagUpdated",
-					Tag:  makeTagInfo(name, tag),
-				})
+				mgr.updatedTagsToSignal[name] = struct{}{}
 			}
 			return mgr.saveState()
 		}()
@@ -1883,10 +1880,7 @@ func (mgr *Manager) attachConverterToTag(tag *tag, tagName string, converter *co
 
 	tag.converters = append(tag.converters, converter)
 	mgr.streamsToConvert[converter.Name()].Or(tag.Matches)
-	mgr.event(Event{
-		Type: "tagUpdated",
-		Tag:  makeTagInfo(tagName, tag),
-	})
+	mgr.updatedTagsToSignal[tagName] = struct{}{}
 	return nil
 }
 
@@ -1897,10 +1891,7 @@ func (mgr *Manager) detachConverterFromTag(tag *tag, tagName string, converter *
 			break
 		}
 	}
-	mgr.event(Event{
-		Type: "tagUpdated",
-		Tag:  makeTagInfo(tagName, tag),
-	})
+	mgr.updatedTagsToSignal[tagName] = struct{}{}
 	// delete/invalidate converter results for all matching streams now
 	// but only if they aren't matches of other tags the converter is attached to.
 	matchingStreams := bitmask.LongBitmask{}
@@ -2700,6 +2691,36 @@ func (mgr *Manager) Listen() (chan Event, func()) {
 				close(ch)
 			}
 			close(l.close)
+		}
+	}
+}
+
+func (mgr *Manager) tagUpdateEventWorker() {
+	ticker := time.NewTicker(tagUpdateEventInterval)
+	for {
+		select {
+		case <-mgr.updatedTagsDone:
+			ticker.Stop()
+			return
+		case <-ticker.C:
+			if len(mgr.updatedTagsToSignal) == 0 {
+				continue
+			}
+			mgr.jobs <- func() {
+				infos := make([]*TagInfo, 0, len(mgr.updatedTagsToSignal))
+				for tn := range mgr.updatedTagsToSignal {
+					delete(mgr.updatedTagsToSignal, tn)
+					t, ok := mgr.tags[tn]
+					if !ok {
+						continue
+					}
+					infos = append(infos, makeTagInfo(tn, t))
+				}
+				mgr.event(Event{
+					Type: "tagUpdated",
+					Tags: infos,
+				})
+			}
 		}
 	}
 }

--- a/internal/index/manager/manager.go
+++ b/internal/index/manager/manager.go
@@ -834,10 +834,7 @@ func (mgr *Manager) updateTagJob(name string, t tag, tagDetails map[string]query
 		mgr.startConverterJobIfNeeded()
 		mgr.startMergeJobIfNeeded()
 		releaser.release(mgr)
-		mgr.event(Event{
-			Type: "tagEvaluated",
-			Tag:  makeTagInfo(name, &t),
-		})
+		mgr.updatedTagsToSignal[name] = struct{}{}
 	}
 }
 

--- a/internal/index/manager/manager_test.go
+++ b/internal/index/manager/manager_test.go
@@ -214,7 +214,7 @@ func TestTags(t *testing.T) {
 	if err := mgr.AddTag("service/foo", "red", "cport:2,3"); err != nil {
 		t.Fatalf("Manager.AddTag failed with error: %v", err)
 	}
-	importSomePackets(t, mgr, t1, "tagEvaluated")
+	importSomePackets(t, mgr, t1, "tagUpdated")
 	if got := mgr.ListTags()[0]; got.MatchingCount != 2 || got.UncertainCount != 0 {
 		t.Fatalf("Manager.ListTags()[0] = %+v, want {MatchingCount: 2, UncertainCount: 0}", got)
 	}

--- a/web/src/apiClient.guard.ts
+++ b/web/src/apiClient.guard.ts
@@ -2,7 +2,7 @@
  * Generated type guards for "apiClient.ts".
  * WARNING: Do not manually change this file.
  */
-import { Error, SearchResult, SearchResponse, StreamData, Statistics, MainStderr, Config, PcapsResponse, ConvertersResponse, ProcessStderr, PcapOverIPResponse, Webhooks, TagsResponse, GraphResponse } from "./apiClient";
+import { Error, SearchResult, SearchResponse, StreamData, Statistics, MainStderr, Config, PcapsResponse, ConvertersResponse, ProcessStderr, PcapOverIPResponse, Webhooks, TagInfo, TagsResponse, GraphResponse } from "./apiClient";
 
 export function isError(obj: unknown): obj is Error {
     const typedObj = obj as Error
@@ -253,24 +253,31 @@ export function isWebhooks(obj: unknown): obj is Webhooks {
     )
 }
 
+export function isTagInfo(obj: unknown): obj is TagInfo {
+    const typedObj = obj as TagInfo
+    return (
+        (typedObj !== null &&
+            typeof typedObj === "object" ||
+            typeof typedObj === "function") &&
+        typeof typedObj["Name"] === "string" &&
+        typeof typedObj["Definition"] === "string" &&
+        typeof typedObj["Color"] === "string" &&
+        typeof typedObj["MatchingCount"] === "number" &&
+        typeof typedObj["UncertainCount"] === "number" &&
+        typeof typedObj["Referenced"] === "boolean" &&
+        Array.isArray(typedObj["Converters"]) &&
+        typedObj["Converters"].every((e: any) =>
+            typeof e === "string"
+        )
+    )
+}
+
 export function isTagsResponse(obj: unknown): obj is TagsResponse {
     const typedObj = obj as TagsResponse
     return (
         Array.isArray(typedObj) &&
         typedObj.every((e: any) =>
-            (e !== null &&
-                typeof e === "object" ||
-                typeof e === "function") &&
-            typeof e["Name"] === "string" &&
-            typeof e["Definition"] === "string" &&
-            typeof e["Color"] === "string" &&
-            typeof e["MatchingCount"] === "number" &&
-            typeof e["UncertainCount"] === "number" &&
-            typeof e["Referenced"] === "boolean" &&
-            Array.isArray(e["Converters"]) &&
-            e["Converters"].every((e: any) =>
-                typeof e === "string"
-            )
+            isTagInfo(e) as boolean
         )
     )
 }

--- a/web/src/apiClient.ts
+++ b/web/src/apiClient.ts
@@ -154,6 +154,7 @@ export type PcapOverIPResponse = PcapOverIPEndpoint[];
 /** @see {isWebhooks} ts-auto-guard:type-guard */
 export type Webhooks = string[];
 
+/** @see {isTagInfo} ts-auto-guard:type-guard */
 export type TagInfo = {
   Name: string;
   Definition: string;

--- a/web/src/stores/websocket.guard.ts
+++ b/web/src/stores/websocket.guard.ts
@@ -2,8 +2,8 @@
  * Generated type guards for "websocket.ts".
  * WARNING: Do not manually change this file.
  */
-import { Event, TagEvent, ConverterEvent, PcapStatsEvent, ConfigEvent, WebhooksEvent, PcapOverIPEndpointsEvent } from "./websocket";
-import { isConfig } from "../apiClient.guard";
+import { Event, TagEvent, TagUpdatedEvent, ConverterEvent, PcapStatsEvent, ConfigEvent, WebhooksEvent, PcapOverIPEndpointsEvent } from "./websocket";
+import { isTagInfo, isConfig } from "../apiClient.guard";
 
 export function isEvent(obj: unknown): obj is Event {
     const typedObj = obj as Event
@@ -23,20 +23,21 @@ export function isTagEvent(obj: unknown): obj is TagEvent {
             typeof typedObj === "function") &&
         (typedObj["Type"] === "tagAdded" ||
             typedObj["Type"] === "tagDeleted" ||
-            typedObj["Type"] === "tagUpdated" ||
             typedObj["Type"] === "tagEvaluated") &&
-        (typedObj["Tag"] !== null &&
-            typeof typedObj["Tag"] === "object" ||
-            typeof typedObj["Tag"] === "function") &&
-        typeof typedObj["Tag"]["Name"] === "string" &&
-        typeof typedObj["Tag"]["Definition"] === "string" &&
-        typeof typedObj["Tag"]["Color"] === "string" &&
-        typeof typedObj["Tag"]["MatchingCount"] === "number" &&
-        typeof typedObj["Tag"]["UncertainCount"] === "number" &&
-        typeof typedObj["Tag"]["Referenced"] === "boolean" &&
-        Array.isArray(typedObj["Tag"]["Converters"]) &&
-        typedObj["Tag"]["Converters"].every((e: any) =>
-            typeof e === "string"
+        isTagInfo(typedObj["Tag"]) as boolean
+    )
+}
+
+export function isTagUpdatedEvent(obj: unknown): obj is TagUpdatedEvent {
+    const typedObj = obj as TagUpdatedEvent
+    return (
+        (typedObj !== null &&
+            typeof typedObj === "object" ||
+            typeof typedObj === "function") &&
+        typedObj["Type"] === "tagUpdated" &&
+        Array.isArray(typedObj["Tags"]) &&
+        typedObj["Tags"].every((e: any) =>
+            isTagInfo(e) as boolean
         )
     )
 }

--- a/web/src/stores/websocket.guard.ts
+++ b/web/src/stores/websocket.guard.ts
@@ -22,8 +22,7 @@ export function isTagEvent(obj: unknown): obj is TagEvent {
             typeof typedObj === "object" ||
             typeof typedObj === "function") &&
         (typedObj["Type"] === "tagAdded" ||
-            typedObj["Type"] === "tagDeleted" ||
-            typedObj["Type"] === "tagEvaluated") &&
+            typedObj["Type"] === "tagDeleted") &&
         isTagInfo(typedObj["Tag"]) as boolean
     )
 }

--- a/web/src/stores/websocket.ts
+++ b/web/src/stores/websocket.ts
@@ -30,7 +30,6 @@ type EventTypes =
   | "tagAdded"
   | "tagDeleted"
   | "tagUpdated"
-  | "tagEvaluated"
   | "webhooksUpdated"
   | "pcapOverIPEndpointsUpdated";
 
@@ -41,7 +40,7 @@ export type Event = {
 
 /** @see {isTagEvent} ts-auto-guard:type-guard */
 export type TagEvent = {
-  Type: "tagAdded" | "tagDeleted" | "tagEvaluated";
+  Type: "tagAdded" | "tagDeleted";
   Tag: TagInfo;
 };
 
@@ -163,16 +162,6 @@ export function setupWebsocket() {
                 result.Tags = result.Tags.filter((tag) => tag !== e.Tag.Name);
                 return result;
               },
-            );
-          break;
-        case "tagEvaluated":
-          if (!isTagEvent(e)) {
-            console.error("Invalid tag event:", e);
-            return;
-          }
-          if (store.tags != null)
-            store.tags = store.tags.map((t) =>
-              t.Name == e.Tag.Name ? e.Tag : t,
             );
           break;
         case "tagUpdated":

--- a/web/src/stores/websocket.ts
+++ b/web/src/stores/websocket.ts
@@ -14,6 +14,7 @@ import {
   isPcapOverIPEndpointsEvent,
   isPcapStatsEvent,
   isTagEvent,
+  isTagUpdatedEvent,
   isWebhooksEvent,
 } from "./websocket.guard";
 
@@ -40,8 +41,14 @@ export type Event = {
 
 /** @see {isTagEvent} ts-auto-guard:type-guard */
 export type TagEvent = {
-  Type: "tagAdded" | "tagDeleted" | "tagUpdated" | "tagEvaluated";
+  Type: "tagAdded" | "tagDeleted" | "tagEvaluated";
   Tag: TagInfo;
+};
+
+/** @see {isTagUpdatedEvent} ts-auto-guard:type-guard */
+export type TagUpdatedEvent = {
+  Type: "tagUpdated";
+  Tags: TagInfo[];
 };
 
 /** @see {isConverterEvent} ts-auto-guard:type-guard */
@@ -158,7 +165,6 @@ export function setupWebsocket() {
               },
             );
           break;
-        case "tagUpdated":
         case "tagEvaluated":
           if (!isTagEvent(e)) {
             console.error("Invalid tag event:", e);
@@ -167,6 +173,16 @@ export function setupWebsocket() {
           if (store.tags != null)
             store.tags = store.tags.map((t) =>
               t.Name == e.Tag.Name ? e.Tag : t,
+            );
+          break;
+        case "tagUpdated":
+          if (!isTagUpdatedEvent(e)) {
+            console.error("Invalid tag updated event:", e);
+            return;
+          }
+          if (store.tags != null)
+            store.tags = store.tags.map(
+              (t) => e.Tags.find((tt) => t.Name == tt.Name) ?? t,
             );
           break;
         case "converterAdded":


### PR DESCRIPTION
The DOM was updated a lot while handling all the tag update messages making pkappa2 laggy on weaker machines. They happened more often when using PCAP-over-IP since small pcaps are frequently added triggering tag reevaluation.

Instead of sending a `tagUpdated` event immediately everytime a tag was updated, only send all of them in a one second interval.

Inspired by @wert310's changes in https://github.com/wert310/pkappa2/commit/1380e3faa614e50a78228fc847c12c65135fa66e, just avoiding the network traffic.

We'll see if there are other events like `pcapProcessed` or `converterCompleted` causing similar trouble, but their effect isn't shown everywhere in the UI.